### PR TITLE
Retry failed tests once in CI

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -33,7 +33,7 @@ const portMap = Object.fromEntries(
 
 export default defineConfig({
 	forbidOnly: !!process.env.CI,
-	retries: 0,
+	retries: process.env.CI ? 1 : 0,
 	workers: 1,
 	reporter: "html",
 	use: {

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Command Palette Tools ===
 Contributors:      kbat82
 Tags:              command palette, productivity, confetti, math, color
-Tested up to:      7.0
+Tested up to:      7.1
 Stable tag:        1.0.0
 License:           GPL-2.0-or-later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
WP Playground intermittently 500s or crashes mid-test in CI, failing a different spec each night across sibling repos. One CI-gated retry absorbs it; local runs stay `retries: 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)