### PR TITLE
Release 1.0.1

### DIFF
--- a/.github/workflows/build-production-zip.yml
+++ b/.github/workflows/build-production-zip.yml
@@ -13,9 +13,9 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         id: setup-node
         with:
           node-version: lts/*
@@ -26,7 +26,7 @@ jobs:
 
       - name: Cache node_modules and npm cache
         id: cache-node-modules
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             node_modules
@@ -50,7 +50,7 @@ jobs:
           CI: true
 
       - name: Package
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: wpcp-tools
           retention-days: 5

--- a/.github/workflows/playwright-nightly.yml
+++ b/.github/workflows/playwright-nightly.yml
@@ -14,7 +14,7 @@ jobs:
     outputs:
       suites: ${{ steps.find.outputs.suites }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - id: find
       run: |
         suites=$(find . -name '*.spec.ts' -not -path '*/node_modules/*' | while read spec; do
@@ -38,9 +38,9 @@ jobs:
         suite: ${{ fromJson(needs.discover.outputs.suites) }}
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
 
-    - uses: actions/setup-node@v6
+    - uses: actions/setup-node@v7
       with:
         node-version: 22
         cache: 'npm'
@@ -52,7 +52,7 @@ jobs:
       run: echo "version=$(npx playwright --version | awk '{print $2}')" >> "$GITHUB_OUTPUT"
 
     - name: Cache Playwright browsers
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       id: pw-cache
       with:
         path: ~/.cache/ms-playwright
@@ -81,7 +81,7 @@ jobs:
       id: artifact
       run: echo "name=pw-nightly-${{ matrix.suite }}" >> "$GITHUB_OUTPUT"
 
-    - uses: actions/upload-artifact@v6
+    - uses: actions/upload-artifact@v7
       if: ${{ !cancelled() }}
       with:
         name: ${{ steps.artifact.outputs.name }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -13,7 +13,7 @@ jobs:
     outputs:
       suites: ${{ steps.find.outputs.suites }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - id: find
       run: |
         suites=$(find . -name '*.spec.ts' -not -path '*/node_modules/*' | while read spec; do
@@ -37,9 +37,9 @@ jobs:
         suite: ${{ fromJson(needs.discover.outputs.suites) }}
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
 
-    - uses: actions/setup-node@v6
+    - uses: actions/setup-node@v7
       with:
         node-version: 22
         cache: 'npm'
@@ -51,7 +51,7 @@ jobs:
       run: echo "version=$(npx playwright --version | awk '{print $2}')" >> "$GITHUB_OUTPUT"
 
     - name: Cache Playwright browsers
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       id: pw-cache
       with:
         path: ~/.cache/ms-playwright
@@ -78,7 +78,7 @@ jobs:
       id: artifact
       run: echo "name=pw-${{ matrix.suite }}" >> "$GITHUB_OUTPUT"
 
-    - uses: actions/upload-artifact@v6
+    - uses: actions/upload-artifact@v7
       if: ${{ !cancelled() }}
       with:
         name: ${{ steps.artifact.outputs.name }}

--- a/.github/workflows/release-to-wp-org.yml
+++ b/.github/workflows/release-to-wp-org.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: lts/*
           cache: 'npm'

--- a/.github/workflows/update-wordpress-readme.yml
+++ b/.github/workflows/update-wordpress-readme.yml
@@ -11,9 +11,9 @@ jobs:
       cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: lts/*
           cache: 'npm'

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors:      kbat82
 Tags:              command palette, productivity, confetti, math, color
 Tested up to:      7.1
-Stable tag:        1.0.0
+Stable tag:        1.0.1
 License:           GPL-2.0-or-later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -44,6 +44,10 @@ WordPress 6.3 comes with a command pallete utility interface that lets you inter
 3. Fire confetti with or without delay
 
 == Changelog ==
+
+= 1.0.1 - 2026-08-15 =
+- Tested up to WordPress 7.1
+- Chore: Update GitHub Actions off the deprecated Node 20 runtime
 
 = 1.0.0 - 2023-11-01 =
 - Initial release

--- a/wpcp-tools.php
+++ b/wpcp-tools.php
@@ -4,7 +4,7 @@
  * Description:       A collection of productivity tools for the WordPress Command Palette
  * Requires at least: 6.3
  * Requires PHP:      7.0
- * Version:           1.0.0
+ * Version:           1.0.1
  * Author:            Kevin Batdorf
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
Cuts 1.0.1 so the 7.1 readme actually reaches wp.org.

The readme-only push bailed: wp.org trunk still holds `tests/` and `test-results/` from deploys predating `.distignore`, so the action saw pending deletions and refused. A release syncs trunk, clears them, and carries the readme — after which readme-only pushes work with the guard intact.

Actions bumped to the current majors (checkout v7, cache v6, setup-node v7, upload-artifact v7). The v4–v6 ones target Node 20, which runners already force onto Node 24 — that's the deprecation notice.

After merge: publish a release tagged `1.0.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)