### PR TITLE
Run the unit tests in CI

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,28 @@
+name: Unit Tests
+permissions:
+  contents: read
+on:
+  pull_request:
+  push:
+    branches: main
+
+jobs:
+  test:
+    name: Unit tests
+    concurrency:
+      group: ${{ github.workflow }} - ${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      # Node 23.6+ so node --test runs the TypeScript sources without a flag.
+      - uses: actions/setup-node@v7
+        with:
+          node-version: lts/*
+          cache: 'npm'
+
+      - run: npm ci --prefer-offline --no-audit --no-fund
+
+      - run: npm run test:unit


### PR DESCRIPTION
The evaluator that replaced mathjs is the only hand-written parser in the repo, and its six tests only ran locally.

- Separate workflow rather than a step in the Playwright matrix, so it doesn't wait on a browser install, and rather than a step in the zip build, so it reports under its own check name.
- `lts/*` is what the other workflows already use and it satisfies the one real constraint here: `node --test` needs Node 23.6+ to run the TypeScript sources without a flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)