### PR TITLE
Load the ability catalog from core's REST listing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@tailwindcss/postcss": "^4.3.3",
+				"@wordpress/api-fetch": "^7.54.0",
 				"@wordpress/block-editor": "^17.0.0",
 				"@wordpress/blocks": "^15.27.0",
 				"@wordpress/commands": "^1.54.0",
@@ -7863,6 +7864,66 @@
 			"engines": {
 				"node": ">=14.0.0"
 			}
+		},
+		"node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+			"version": "1.11.1",
+			"inBundle": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/wasi-threads": "1.2.2",
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+			"version": "1.11.1",
+			"inBundle": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+			"version": "1.2.2",
+			"inBundle": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+			"version": "1.1.4",
+			"inBundle": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@tybys/wasm-util": "^0.10.1"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
+			},
+			"peerDependencies": {
+				"@emnapi/core": "^1.7.1",
+				"@emnapi/runtime": "^1.7.1"
+			}
+		},
+		"node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+			"version": "0.10.2",
+			"inBundle": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+			"version": "2.8.1",
+			"inBundle": true,
+			"license": "0BSD",
+			"optional": true
 		},
 		"node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
 			"version": "4.3.3",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
 	},
 	"dependencies": {
 		"@tailwindcss/postcss": "^4.3.3",
+		"@wordpress/api-fetch": "^7.54.0",
 		"@wordpress/block-editor": "^17.0.0",
 		"@wordpress/blocks": "^15.27.0",
 		"@wordpress/commands": "^1.54.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -31,6 +31,12 @@ const portMap = Object.fromEntries(
 	blueprints.map((bp, i) => [bp, BASE_PORT + i]),
 );
 
+// requestUtils finds the REST root from WP_BASE_URL, not the project baseURL,
+// so rest() calls hit port 8889 without this. One port fits one blueprint.
+if (blueprints.length === 1) {
+	process.env.WP_BASE_URL = `http://127.0.0.1:${portMap[blueprints[0]]}`;
+}
+
 export default defineConfig({
 	forbidOnly: !!process.env.CI,
 	retries: 0,

--- a/readme.txt
+++ b/readme.txt
@@ -46,11 +46,6 @@ WordPress 6.3 comes with a command pallete utility interface that lets you inter
 
 == Changelog ==
 
-= 2.0.0 - Unreleased =
-- Requires WordPress 6.9 or later
-- Fix: translations now load — the text domain has to match the plugin slug, and it did not
-- Note: the main plugin file was renamed, so WordPress deactivates the plugin when it updates. Reactivate it from the Plugins screen.
-
 = 1.0.1 - 2026-08-15 =
 - Tested up to WordPress 7.1
 - Chore: Update GitHub Actions off the deprecated Node 20 runtime

--- a/src/lib/abilities.ts
+++ b/src/lib/abilities.ts
@@ -1,0 +1,120 @@
+// Shapes returned by core's ability listing, `GET wp-abilities/v1/abilities`.
+
+export type JsonSchema = {
+	type?: string | string[];
+	title?: string;
+	description?: string;
+	properties?: Record<string, JsonSchema>;
+	items?: JsonSchema;
+	enum?: unknown[];
+	required?: string[];
+	default?: unknown;
+	additionalProperties?: boolean | JsonSchema;
+	[key: string]: unknown;
+};
+
+export type AbilityAnnotations = {
+	readonly?: boolean;
+	destructive?: boolean;
+	idempotent?: boolean;
+};
+
+export type Ability = {
+	name: string;
+	label: string;
+	description: string;
+	category: string;
+	input_schema?: JsonSchema;
+	output_schema?: JsonSchema;
+	meta?: { annotations?: AbilityAnnotations } & Record<string, unknown>;
+	_links?: Record<string, { href: string }[] | undefined>;
+};
+
+export type Catalog = {
+	abilities: Ability[];
+	hash: string;
+	// Null with an empty list means nothing was registered, not a failed request.
+	error: string | null;
+};
+
+const EMPTY_CATALOG: Catalog = { abilities: [], hash: "", error: null };
+
+// Ability names contain a slash, so the run URL cannot be built from the name.
+const RUN_REL = "wp:action-run";
+
+export const runHref = (ability: Ability) =>
+	ability._links?.[RUN_REL]?.[0]?.href ?? null;
+
+const isAbility = (value: unknown): value is Ability =>
+	typeof value === "object" &&
+	value !== null &&
+	typeof (value as Ability).name === "string" &&
+	typeof (value as Ability).label === "string";
+
+// Only the code separates a missing abilities route from a refused read.
+const restErrorCode = (error: unknown) => {
+	const code = (error as { code?: unknown } | null | undefined)?.code;
+	return typeof code === "string" ? code : "unknown_error";
+};
+
+// cyrb53, not a digest: crypto.subtle is async and missing on http:// admin.
+// Sorted so reordering is the same catalog; over the text, so an edit invalidates.
+export const catalogHash = (abilities: Ability[]) => {
+	const text = abilities
+		.map(({ name, label, description }) => [name, label, description].join(" "))
+		.sort()
+		.join("");
+
+	let h1 = 0xdeadbeef;
+	let h2 = 0x41c6ce57;
+	for (let i = 0; i < text.length; i++) {
+		const ch = text.charCodeAt(i);
+		h1 = Math.imul(h1 ^ ch, 2654435761);
+		h2 = Math.imul(h2 ^ ch, 1597334677);
+	}
+	h1 =
+		Math.imul(h1 ^ (h1 >>> 16), 2246822507) ^
+		Math.imul(h2 ^ (h2 >>> 13), 3266489909);
+	h2 =
+		Math.imul(h2 ^ (h2 >>> 16), 2246822507) ^
+		Math.imul(h1 ^ (h1 >>> 13), 3266489909);
+
+	return (4294967296 * (2097151 & h2) + (h1 >>> 0)).toString(36);
+};
+
+export type CatalogLoader = {
+	load: () => Promise<Catalog>;
+	clear: () => void;
+};
+
+export const createCatalogLoader = (
+	fetchAbilities: () => Promise<unknown>,
+): CatalogLoader => {
+	let pending: Promise<Catalog> | null = null;
+
+	const fetchCatalog = async (): Promise<Catalog> => {
+		let payload: unknown;
+		try {
+			payload = await fetchAbilities();
+		} catch (error) {
+			return { ...EMPTY_CATALOG, error: restErrorCode(error) };
+		}
+		if (!Array.isArray(payload)) {
+			return { ...EMPTY_CATALOG, error: "unexpected_response" };
+		}
+		const abilities = payload.filter(isAbility);
+		return { abilities, hash: catalogHash(abilities), error: null };
+	};
+
+	return {
+		load: () =>
+			(pending ??= fetchCatalog().then((catalog) => {
+				// Caching a failure would make one dead request permanent.
+				if (catalog.error) pending = null;
+				return catalog;
+			})),
+		clear: () => {
+			pending = null;
+		},
+	};
+};

--- a/src/lib/ability-catalog.ts
+++ b/src/lib/ability-catalog.ts
@@ -1,0 +1,10 @@
+import apiFetch from "@wordpress/api-fetch";
+import { createCatalogLoader } from "./abilities";
+
+// per_page=-1 is api-fetch's convention, not a value core accepts: it rewrites
+// to 100 and follows the listing's `Link: rel="next"` to the end.
+const CATALOG_PATH = "/wp-abilities/v1/abilities?per_page=-1";
+
+export const abilityCatalog = createCatalogLoader(() =>
+	apiFetch({ path: CATALOG_PATH }),
+);

--- a/tests/abilities.spec.ts
+++ b/tests/abilities.spec.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "@wordpress/e2e-test-utils-playwright";
+import { type Ability, runHref } from "../src/lib/abilities.ts";
+
+const CATALOG = "/wp-abilities/v1/abilities";
+
+test.beforeEach(async ({ requestUtils }) => {
+	await requestUtils.login();
+});
+
+test("a stock site lists the abilities the catalog is built from", async ({
+	requestUtils,
+}) => {
+	const abilities = await requestUtils.rest<Ability[]>({ path: CATALOG });
+
+	expect(abilities.map(({ name }) => name)).toEqual(
+		expect.arrayContaining([
+			"core/get-site-info",
+			"core/get-user-info",
+			"core/get-environment-info",
+		]),
+	);
+
+	for (const ability of abilities) {
+		expect(ability.label).toBeTruthy();
+		expect(ability.category).toBeTruthy();
+		expect(ability.input_schema).toBeDefined();
+		expect(ability.meta?.annotations).toBeDefined();
+		expect(runHref(ability)).toContain(`${ability.name}/run`);
+	}
+});
+
+// per_page=-1 walks pages by this header alone; losing it truncates at 100.
+test("the listing advertises its next page", async ({ requestUtils }) => {
+	const { rootURL, nonce } = await requestUtils.setupRest();
+
+	const response = await requestUtils.request.fetch(
+		`${rootURL}wp-abilities/v1/abilities?per_page=1`,
+		{ headers: { "X-WP-Nonce": nonce } },
+	);
+
+	expect(response.headers().link).toContain('rel="next"');
+});

--- a/tests/unit/abilities.test.ts
+++ b/tests/unit/abilities.test.ts
@@ -1,0 +1,157 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+	type Ability,
+	catalogHash,
+	createCatalogLoader,
+	runHref,
+} from "../../src/lib/abilities.ts";
+
+const ability = (overrides: Partial<Ability> = {}): Ability => ({
+	name: "core/get-site-info",
+	label: "Get Site Information",
+	description: "Returns site information configured in WordPress.",
+	category: "site",
+	input_schema: { type: "object", properties: {} },
+	meta: { annotations: { readonly: true, destructive: false } },
+	_links: {
+		"wp:action-run": [
+			{ href: "https://example.com/wp-json/wp-abilities/v1/abilities/x/run" },
+		],
+	},
+	...overrides,
+});
+
+describe("runHref", () => {
+	it("reads the run link core advertises", () => {
+		assert.equal(
+			runHref(ability()),
+			"https://example.com/wp-json/wp-abilities/v1/abilities/x/run",
+		);
+	});
+
+	it("returns null when the ability cannot be run over REST", () => {
+		assert.equal(runHref(ability({ _links: {} })), null);
+		assert.equal(runHref(ability({ _links: undefined })), null);
+	});
+});
+
+describe("catalogHash", () => {
+	it("ignores the order the listing came back in", () => {
+		const a = ability({ name: "core/a" });
+		const b = ability({ name: "core/b" });
+		assert.equal(catalogHash([a, b]), catalogHash([b, a]));
+	});
+
+	it("changes when an ability's text changes", () => {
+		const before = catalogHash([ability()]);
+		assert.notEqual(before, catalogHash([ability({ label: "Site info" })]));
+		assert.notEqual(before, catalogHash([ability({ description: "Other." })]));
+		assert.notEqual(before, catalogHash([ability(), ability({ name: "x/y" })]));
+	});
+
+	it("does not collide an empty catalog with a populated one", () => {
+		assert.notEqual(catalogHash([]), catalogHash([ability()]));
+	});
+});
+
+describe("createCatalogLoader", () => {
+	it("returns what the listing gave it, with a hash", async () => {
+		const abilities = [ability()];
+		const loader = createCatalogLoader(async () => abilities);
+
+		const catalog = await loader.load();
+
+		assert.deepEqual(catalog.abilities, abilities);
+		assert.equal(catalog.hash, catalogHash(abilities));
+		assert.equal(catalog.error, null);
+	});
+
+	it("reports an empty catalog without an error", async () => {
+		const catalog = await createCatalogLoader(async () => []).load();
+
+		assert.deepEqual(catalog.abilities, []);
+		assert.equal(catalog.error, null);
+	});
+
+	it("surfaces the REST error code instead of throwing", async () => {
+		const loader = createCatalogLoader(async () => {
+			throw { code: "rest_no_route", message: "No route was found." };
+		});
+
+		const catalog = await loader.load();
+
+		assert.deepEqual(catalog.abilities, []);
+		assert.equal(catalog.error, "rest_no_route");
+	});
+
+	it("falls back to a generic code for a thrown non-REST error", async () => {
+		const loader = createCatalogLoader(async () => {
+			throw new TypeError("Failed to fetch");
+		});
+
+		assert.equal((await loader.load()).error, "unknown_error");
+	});
+
+	it("rejects a response that is not a list", async () => {
+		const loader = createCatalogLoader(async () => ({ abilities: [] }));
+
+		assert.equal((await loader.load()).error, "unexpected_response");
+	});
+
+	it("drops entries that are not abilities", async () => {
+		const loader = createCatalogLoader(async () => [
+			ability(),
+			{ name: "core/nameless" },
+			null,
+			"core/get-site-info",
+		]);
+
+		assert.deepEqual(
+			(await loader.load()).abilities.map(({ name }) => name),
+			["core/get-site-info"],
+		);
+	});
+
+	it("fetches once for concurrent and repeat callers", async () => {
+		let calls = 0;
+		const loader = createCatalogLoader(async () => {
+			calls++;
+			return [ability()];
+		});
+
+		await Promise.all([loader.load(), loader.load()]);
+		await loader.load();
+
+		assert.equal(calls, 1);
+	});
+
+	it("retries after a failure but not after a success", async () => {
+		let calls = 0;
+		const loader = createCatalogLoader(async () => {
+			calls++;
+			if (calls === 1) throw { code: "rest_forbidden" };
+			return [ability()];
+		});
+
+		assert.equal((await loader.load()).error, "rest_forbidden");
+		assert.equal((await loader.load()).error, null);
+		await loader.load();
+
+		assert.equal(calls, 2);
+	});
+
+	it("refetches after clear", async () => {
+		let calls = 0;
+		const loader = createCatalogLoader(async () => {
+			calls++;
+			return [];
+		});
+
+		await loader.load();
+		loader.clear();
+		await loader.load();
+
+		assert.equal(calls, 2);
+	});
+});


### PR DESCRIPTION
The palette can't rank or run anything until it knows which abilities a site has. This reads that list from WordPress itself, which already hands over everything needed: what to show, what the form should ask for, and where to send it.

- WordPress returns the list 100 at a time. Instead of paging through it by hand, this asks for all of it and lets WordPress's own client walk the pages. A test checks the signpost it follows is still there — if that ever goes away, the list would quietly stop at 100 and still look fine.
- A failed request isn't remembered, so one bad moment during a page load doesn't leave the palette empty until a reload. A site with nothing registered reads differently to a site that refused the request, and stays that way.
- Also drops the unreleased changelog entry added last time. The job that publishes to wordpress.org pushes `readme.txt` on its own whenever a commit changed nothing else, and the copy it writes is what the public listing shows — so an entry sitting there before release is a way to accidentally tell visitors the current version needs WordPress 6.9.

Nothing imports the new code yet, so the plugin behaves exactly as it did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)