### PR TITLE
Open an ability palette on any admin screen

### DIFF
--- a/command-palette-tools.php
+++ b/command-palette-tools.php
@@ -21,6 +21,47 @@ function wpcp_tools_has_abilities_api()
 	return function_exists('wp_register_ability') && function_exists('wp_get_abilities');
 }
 
+function wpcp_tools_palette_enabled()
+{
+	if (defined('disable_wpcp_tools_palette')) return false;
+	if (is_network_admin() || is_user_admin()) return false;
+	if (!wpcp_tools_has_abilities_api()) return false;
+
+	return current_user_can('edit_posts');
+}
+
+add_action('admin_enqueue_scripts', function () {
+	if (!wpcp_tools_palette_enabled()) return;
+
+	$deps = require plugin_dir_path(__FILE__) . 'build/palette.asset.php';
+	wp_enqueue_script(
+		'kevinbatdorf/wpcp-tools-palette',
+		plugins_url('build/palette.js', __FILE__),
+		$deps['dependencies'],
+		$deps['version'],
+		true
+	);
+	wp_set_script_translations('kevinbatdorf/wpcp-tools-palette', 'command-palette-tools');
+	// Core's own stylesheets; without them the palette renders unstyled.
+	wp_enqueue_style(
+		'kevinbatdorf/wpcp-tools-palette',
+		plugins_url('build/palette.css', __FILE__),
+		['wp-components', 'wp-commands'],
+		$deps['version']
+	);
+	wp_style_add_data('kevinbatdorf/wpcp-tools-palette', 'rtl', 'replace');
+});
+
+add_action('admin_bar_menu', function ($wp_admin_bar) {
+	if (!is_admin() || !wpcp_tools_palette_enabled()) return;
+
+	$wp_admin_bar->add_node([
+		'id' => 'wpcp-tools-palette',
+		'title' => __('Abilities', 'command-palette-tools'),
+		'href' => '#',
+	]);
+}, 100);
+
 $wpcp_tools_assets = ['math', 'color', 'fun'];
 
 add_action('enqueue_block_editor_assets', function () use ($wpcp_tools_assets) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
 				"@wordpress/icons": "^15.5.0",
 				"@wordpress/plugins": "^7.54.0",
 				"canvas-confetti": "^1.9.4",
+				"cmdk": "^1.1.1",
 				"colord": "^2.10.0",
 				"copy-to-clipboard": "^4.0.2",
 				"postcss": "^8.5.26",
@@ -2645,6 +2646,7 @@
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
 			"integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -2656,6 +2658,7 @@
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
 			"integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -2666,6 +2669,7 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
 			"integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -4456,6 +4460,7 @@
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.3.tgz",
 			"integrity": "sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q==",
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -8060,6 +8065,7 @@
 			"version": "0.10.3",
 			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
 			"integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
 		"@wordpress/icons": "^15.5.0",
 		"@wordpress/plugins": "^7.54.0",
 		"canvas-confetti": "^1.9.4",
+		"cmdk": "^1.1.1",
 		"colord": "^2.10.0",
 		"copy-to-clipboard": "^4.0.2",
 		"postcss": "^8.5.26",

--- a/src/lib/abilities.ts
+++ b/src/lib/abilities.ts
@@ -82,6 +82,36 @@ export const catalogHash = (abilities: Ability[]) => {
 	return (4294967296 * (2097151 & h2) + (h1 >>> 0)).toString(36);
 };
 
+export type CatalogState =
+	| "ready"
+	| "empty"
+	| "unavailable"
+	| "forbidden"
+	| "failed";
+
+const FORBIDDEN_CODES = new Set([
+	"rest_forbidden",
+	"rest_cannot_view",
+	"rest_cookie_invalid_nonce",
+]);
+
+export const catalogState = (catalog: Catalog): CatalogState => {
+	if (catalog.error === "rest_no_route") return "unavailable";
+	if (catalog.error) {
+		return FORBIDDEN_CODES.has(catalog.error) ? "forbidden" : "failed";
+	}
+	return catalog.abilities.length ? "ready" : "empty";
+};
+
+export const filterAbilities = (abilities: Ability[], search: string) => {
+	const query = search.trim().toLowerCase();
+	if (!query) return abilities;
+
+	return abilities.filter(({ name, label, description }) =>
+		`${label} ${description} ${name}`.toLowerCase().includes(query),
+	);
+};
+
 export type CatalogLoader = {
 	load: () => Promise<Catalog>;
 	clear: () => void;

--- a/src/lib/abilities.ts
+++ b/src/lib/abilities.ts
@@ -103,6 +103,14 @@ export const catalogState = (catalog: Catalog): CatalogState => {
 	return catalog.abilities.length ? "ready" : "empty";
 };
 
+// The listing carries no namespace field of its own.
+export const abilitySource = ({ name, category }: Ability) => {
+	const [namespace] = name.split("/");
+	if (!namespace || namespace === name) return category;
+
+	return category ? `${namespace}:${category}` : namespace;
+};
+
 export const filterAbilities = (abilities: Ability[], search: string) => {
 	const query = search.trim().toLowerCase();
 	if (!query) return abilities;

--- a/src/palette/palette-menu.tsx
+++ b/src/palette/palette-menu.tsx
@@ -11,6 +11,7 @@ import { __, _n, sprintf } from "@wordpress/i18n";
 import { Icon, search as searchIcon } from "@wordpress/icons";
 import { Command } from "cmdk";
 import {
+	abilitySource,
 	type Catalog,
 	type CatalogState,
 	catalogState,
@@ -154,7 +155,7 @@ export const PaletteMenu = () => {
 												{ability.label}
 											</span>
 											<span className="commands-command-menu__item-category">
-												{ability.category}
+												{abilitySource(ability)}
 											</span>
 										</div>
 									</Command.Item>

--- a/src/palette/palette-menu.tsx
+++ b/src/palette/palette-menu.tsx
@@ -1,0 +1,169 @@
+import { speak } from "@wordpress/a11y";
+import { Modal } from "@wordpress/components";
+import {
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from "@wordpress/element";
+import { __, _n, sprintf } from "@wordpress/i18n";
+import { Icon, search as searchIcon } from "@wordpress/icons";
+import { Command } from "cmdk";
+import {
+	type Catalog,
+	type CatalogState,
+	catalogState,
+	filterAbilities,
+} from "../lib/abilities";
+import { abilityCatalog } from "../lib/ability-catalog";
+import { useOpenPalette } from "./use-open-palette";
+
+const notice = (state: CatalogState) => {
+	switch (state) {
+		case "unavailable":
+			return __(
+				"This site does not offer the Abilities API.",
+				"command-palette-tools",
+			);
+		case "forbidden":
+			return __(
+				"You are not allowed to list abilities.",
+				"command-palette-tools",
+			);
+		case "failed":
+			return __("Abilities could not be loaded.", "command-palette-tools");
+		default:
+			return __(
+				"No abilities are registered on this site.",
+				"command-palette-tools",
+			);
+	}
+};
+
+export const PaletteMenu = () => {
+	const [isOpen, setIsOpen] = useState(false);
+	const [search, setSearch] = useState("");
+	const [catalog, setCatalog] = useState<Catalog | null>(null);
+
+	const input = useRef<HTMLInputElement>(null);
+
+	const toggle = useCallback(() => setIsOpen((open) => !open), []);
+	useOpenPalette(toggle);
+
+	// Modal focuses its frame, not the search field, so typing would go nowhere.
+	useEffect(() => {
+		input.current?.focus();
+	}, [isOpen]);
+
+	// Admin-wide, so fetching on mount would hit every admin page load.
+	useEffect(() => {
+		if (!isOpen) return;
+
+		let stale = false;
+		abilityCatalog.load().then((loaded) => {
+			if (!stale) setCatalog(loaded);
+		});
+		return () => {
+			stale = true;
+		};
+	}, [isOpen]);
+
+	const abilities = useMemo(
+		() => filterAbilities(catalog?.abilities ?? [], search),
+		[catalog, search],
+	);
+	const state = catalog && catalogState(catalog);
+	const count = abilities.length;
+
+	useEffect(() => {
+		if (!isOpen || state !== "ready") return;
+
+		// Waits out the keystroke so a screen reader announces one total, not six.
+		const timer = setTimeout(() => {
+			speak(
+				sprintf(
+					/* translators: %d: how many abilities match what was typed. */
+					_n(
+						"%d ability found.",
+						"%d abilities found.",
+						count,
+						"command-palette-tools",
+					),
+					count,
+				),
+			);
+		}, 500);
+		return () => clearTimeout(timer);
+	}, [count, isOpen, state]);
+
+	if (!isOpen) return null;
+
+	const close = () => {
+		setSearch("");
+		setIsOpen(false);
+	};
+
+	return (
+		<Modal
+			className="commands-command-menu wpcp-tools-palette"
+			overlayClassName="commands-command-menu__overlay"
+			onRequestClose={close}
+			__experimentalHideHeader
+			size="medium"
+			contentLabel={__("Ability palette", "command-palette-tools")}
+		>
+			<div className="commands-command-menu__container">
+				<Command
+					label={__("Search abilities", "command-palette-tools")}
+					shouldFilter={false}
+					loop
+				>
+					<div className="commands-command-menu__header">
+						<Icon
+							className="commands-command-menu__header-search-icon"
+							icon={searchIcon}
+						/>
+						<Command.Input
+							ref={input}
+							value={search}
+							onValueChange={setSearch}
+							placeholder={__("Search abilities", "command-palette-tools")}
+						/>
+					</div>
+					<Command.List label={__("Abilities", "command-palette-tools")}>
+						{state === null && (
+							<Command.Loading>
+								{__("Loading abilities…", "command-palette-tools")}
+							</Command.Loading>
+						)}
+						{state !== null && state !== "ready" && (
+							<Command.Empty>{notice(state)}</Command.Empty>
+						)}
+						{state === "ready" && count === 0 && (
+							<Command.Empty>
+								{__("No abilities found.", "command-palette-tools")}
+							</Command.Empty>
+						)}
+						{state === "ready" && count > 0 && (
+							<Command.Group heading={__("Abilities", "command-palette-tools")}>
+								{abilities.map((ability) => (
+									<Command.Item key={ability.name} value={ability.name}>
+										<div className="commands-command-menu__item">
+											<span className="commands-command-menu__item-label">
+												{ability.label}
+											</span>
+											<span className="commands-command-menu__item-category">
+												{ability.category}
+											</span>
+										</div>
+									</Command.Item>
+								))}
+							</Command.Group>
+						)}
+					</Command.List>
+				</Command>
+			</div>
+		</Modal>
+	);
+};

--- a/src/palette/palette.css
+++ b/src/palette/palette.css
@@ -1,8 +1,9 @@
-/* Core lays this row out with HStack's inline flex, not with a rule. */
+/* Core styles this row for an icon we have none of: 40px indent, no flex. */
 /* no-prefix */
-.wpcp-tools-palette .commands-command-menu__item {
+.wpcp-tools-palette [cmdk-item] > .commands-command-menu__item {
 	display: flex;
 	align-items: center;
 	gap: 8px;
 	width: 100%;
+	padding-left: 8px;
 }

--- a/src/palette/palette.css
+++ b/src/palette/palette.css
@@ -1,0 +1,8 @@
+/* Core lays this row out with HStack's inline flex, not with a rule. */
+/* no-prefix */
+.wpcp-tools-palette .commands-command-menu__item {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	width: 100%;
+}

--- a/src/palette/palette.tsx
+++ b/src/palette/palette.tsx
@@ -1,0 +1,10 @@
+import { createRoot } from "@wordpress/element";
+import "./palette.css";
+import { PaletteMenu } from "./palette-menu";
+
+// Nothing prints a container for it, and Modal portals to the body anyway.
+const root = document.createElement("div");
+root.className = "wpcp-tools-palette-root";
+document.body.append(root);
+
+createRoot(root).render(<PaletteMenu />);

--- a/src/palette/use-open-palette.ts
+++ b/src/palette/use-open-palette.ts
@@ -1,0 +1,58 @@
+import { useDispatch } from "@wordpress/data";
+import { useEffect } from "@wordpress/element";
+import { __ } from "@wordpress/i18n";
+import {
+	store as keyboardShortcutsStore,
+	__unstableUseShortcutEventMatch as useShortcutEventMatch,
+} from "@wordpress/keyboard-shortcuts";
+import { isKeyboardEvent } from "@wordpress/keycodes";
+
+export const OPEN_SHORTCUT = "command-palette-tools/open";
+
+const ADMIN_BAR_TRIGGER = "#wp-admin-bar-wpcp-tools-palette a";
+
+export const useOpenPalette = (toggle: () => void) => {
+	const { registerShortcut } = useDispatch(keyboardShortcutsStore);
+	const isMatch = useShortcutEventMatch();
+
+	// Registering only puts it in the shortcut help modal; it binds nothing.
+	useEffect(() => {
+		registerShortcut({
+			name: OPEN_SHORTCUT,
+			category: "global",
+			description: __("Open the ability palette.", "command-palette-tools"),
+			keyCombination: { modifier: "primary", character: "j" },
+		});
+	}, [registerShortcut]);
+
+	useEffect(() => {
+		const onKeyDown = (event: KeyboardEvent) => {
+			if (event.defaultPrevented) return;
+
+			// Core's palette owns Cmd+K wherever it is mounted.
+			const claimsK =
+				!window.wp?.commands && isKeyboardEvent.primary(event, "k");
+			if (!claimsK && !isMatch(OPEN_SHORTCUT, event)) return;
+
+			event.preventDefault();
+			toggle();
+		};
+
+		// useShortcut only fires inside a ShortcutProvider; admin screens have none.
+		document.addEventListener("keydown", onKeyDown);
+		return () => document.removeEventListener("keydown", onKeyDown);
+	}, [isMatch, toggle]);
+
+	useEffect(() => {
+		const trigger = document.querySelector(ADMIN_BAR_TRIGGER);
+		if (!trigger) return;
+
+		const onClick = (event: Event) => {
+			event.preventDefault();
+			toggle();
+		};
+
+		trigger.addEventListener("click", onClick);
+		return () => trigger.removeEventListener("click", onClick);
+	}, [toggle]);
+};

--- a/tests/palette.spec.ts
+++ b/tests/palette.spec.ts
@@ -1,0 +1,91 @@
+import { expect, test } from "@wordpress/e2e-test-utils-playwright";
+
+const modifier = process.platform === "darwin" ? "Meta" : "Control";
+
+test.beforeEach(async ({ requestUtils }) => {
+	await requestUtils.login();
+});
+
+test("opens and closes on any admin screen", async ({ admin, page }) => {
+	const palette = page.getByRole("dialog", { name: "Ability palette" });
+
+	for (const screen of ["plugins.php", "edit.php", "options-general.php"]) {
+		await admin.visitAdminPage(screen);
+
+		await page.keyboard.press(`${modifier}+j`);
+		await expect(palette).toBeVisible();
+
+		await page.keyboard.press("Escape");
+		await expect(palette).toBeHidden();
+	}
+});
+
+test("lists the abilities core registers and narrows them by search", async ({
+	admin,
+	page,
+}) => {
+	await admin.visitAdminPage("plugins.php");
+	await page.keyboard.press(`${modifier}+j`);
+
+	const palette = page.getByRole("dialog", { name: "Ability palette" });
+	await expect(palette.getByRole("option")).toHaveText([
+		/Get Site Information/,
+		/Get User Information/,
+		/Get Environment Info/,
+	]);
+
+	// Typing reaches the field only because the palette focuses it on open.
+	await page.keyboard.type("user");
+	await expect(palette.getByRole("option")).toHaveText([
+		/Get User Information/,
+	]);
+
+	await page.keyboard.type("zzz");
+	await expect(palette.getByText("No abilities found.")).toBeVisible();
+});
+
+test("a keyboard-only pass reaches every result and dismisses the palette", async ({
+	admin,
+	page,
+}) => {
+	await admin.visitAdminPage("options-general.php");
+	await page.keyboard.press(`${modifier}+j`);
+
+	const palette = page.getByRole("dialog", { name: "Ability palette" });
+	const options = palette.getByRole("option");
+	await expect(options.first()).toHaveAttribute("aria-selected", "true");
+
+	await page.keyboard.press("ArrowDown");
+	await expect(options.nth(1)).toHaveAttribute("aria-selected", "true");
+
+	// `loop` on the palette, so the last result wraps back to the first.
+	await page.keyboard.press("ArrowUp");
+	await page.keyboard.press("ArrowUp");
+	await expect(options.last()).toHaveAttribute("aria-selected", "true");
+
+	await page.keyboard.press("Escape");
+	await expect(palette).toBeHidden();
+});
+
+test("the admin bar item opens the palette", async ({ admin, page }) => {
+	await admin.visitAdminPage("plugins.php");
+
+	await page.locator("#wp-admin-bar-wpcp-tools-palette a").click();
+
+	await expect(
+		page.getByRole("dialog", { name: "Ability palette" }),
+	).toBeVisible();
+});
+
+test("Cmd+K still belongs to core's palette", async ({ admin, page }) => {
+	await admin.visitAdminPage("plugins.php");
+
+	await page.keyboard.press(`${modifier}+k`);
+
+	await expect(
+		page.getByRole("dialog", { name: "Command palette" }),
+	).toBeVisible();
+	await expect(
+		page.getByRole("dialog", { name: "Ability palette" }),
+	).toBeHidden();
+});

--- a/tests/unit/abilities.test.ts
+++ b/tests/unit/abilities.test.ts
@@ -2,8 +2,11 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
 	type Ability,
+	type Catalog,
 	catalogHash,
+	catalogState,
 	createCatalogLoader,
+	filterAbilities,
 	runHref,
 } from "../../src/lib/abilities.ts";
 
@@ -153,5 +156,77 @@ describe("createCatalogLoader", () => {
 		await loader.load();
 
 		assert.equal(calls, 2);
+	});
+});
+
+describe("catalogState", () => {
+	const catalog = (overrides: Partial<Catalog> = {}): Catalog => ({
+		abilities: [ability()],
+		hash: "x",
+		error: null,
+		...overrides,
+	});
+
+	it("separates nothing registered from nothing loaded", () => {
+		assert.equal(catalogState(catalog()), "ready");
+		assert.equal(catalogState(catalog({ abilities: [] })), "empty");
+	});
+
+	it("tells a missing route apart from a refused one", () => {
+		assert.equal(
+			catalogState(catalog({ abilities: [], error: "rest_no_route" })),
+			"unavailable",
+		);
+		assert.equal(
+			catalogState(catalog({ abilities: [], error: "rest_forbidden" })),
+			"forbidden",
+		);
+		assert.equal(
+			catalogState(
+				catalog({ abilities: [], error: "rest_cookie_invalid_nonce" }),
+			),
+			"forbidden",
+		);
+	});
+
+	it("falls back to a plain failure for an unrecognised code", () => {
+		assert.equal(
+			catalogState(catalog({ abilities: [], error: "unknown_error" })),
+			"failed",
+		);
+	});
+});
+
+describe("filterAbilities", () => {
+	const abilities = [
+		ability(),
+		ability({
+			name: "woo/update-price",
+			label: "Update product price",
+			description: "Sets the price on a product.",
+		}),
+	];
+
+	it("returns everything for a blank search", () => {
+		assert.equal(filterAbilities(abilities, "   ").length, 2);
+	});
+
+	it("matches the label, the description and the name", () => {
+		assert.deepEqual(
+			filterAbilities(abilities, "PRODUCT").map(({ name }) => name),
+			["woo/update-price"],
+		);
+		assert.deepEqual(
+			filterAbilities(abilities, "sets the price").map(({ name }) => name),
+			["woo/update-price"],
+		);
+		assert.deepEqual(
+			filterAbilities(abilities, "core/get").map(({ name }) => name),
+			["core/get-site-info"],
+		);
+	});
+
+	it("returns nothing when the search matches nothing", () => {
+		assert.deepEqual(filterAbilities(abilities, "zzz"), []);
 	});
 });

--- a/tests/unit/abilities.test.ts
+++ b/tests/unit/abilities.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
 	type Ability,
+	abilitySource,
 	type Catalog,
 	catalogHash,
 	catalogState,
@@ -228,5 +229,20 @@ describe("filterAbilities", () => {
 
 	it("returns nothing when the search matches nothing", () => {
 		assert.deepEqual(filterAbilities(abilities, "zzz"), []);
+	});
+});
+
+describe("abilitySource", () => {
+	it("names the plugin the ability came from alongside its category", () => {
+		assert.equal(abilitySource(ability()), "core:site");
+		assert.equal(
+			abilitySource(ability({ name: "woo/update-price", category: "product" })),
+			"woo:product",
+		);
+	});
+
+	it("falls back when either half is missing", () => {
+		assert.equal(abilitySource(ability({ name: "nameless" })), "site");
+		assert.equal(abilitySource(ability({ category: "" })), "core");
 	});
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,6 +30,7 @@ config.entry = {
 	math: "./src/commands/math/math.tsx",
 	color: "./src/commands/color/color.tsx",
 	fun: "./src/commands/fun/fun.tsx",
+	palette: "./src/palette/palette.tsx",
 };
 
 export default config;


### PR DESCRIPTION
Press Cmd+J on any admin page and a search box opens listing the abilities registered on the site — the machine-readable actions WordPress 6.9 added, which plugins register so other tools can find and run them. For now it only lists and filters them; picking one does nothing yet. There's an "Abilities" item in the admin bar too, because a keyboard shortcut nobody can see is a shortcut nobody uses.

Cmd+K still opens WordPress' own palette, which since 7.1 is on every admin screen rather than just the editor.

- Adds 52KB to an admin page. That's the whole cost — WordPress already loads React and its own palette everywhere, so every other piece this needs is on the page already.
- Nothing is bundled for the look. It declares WordPress' own palette stylesheet as a dependency, so it matches whatever version of WordPress is running, right-to-left languages included.

_PR description generated by Claude._