### PR TITLE
Build a form from an ability's input schema when one is picked

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
 				"@wordpress/block-editor": "^17.0.0",
 				"@wordpress/blocks": "^15.27.0",
 				"@wordpress/commands": "^1.54.0",
+				"@wordpress/components": "^40.0.0",
 				"@wordpress/edit-post": "^8.54.0",
 				"@wordpress/element": "^8.6.0",
 				"@wordpress/i18n": "^6.27.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
 		"@wordpress/block-editor": "^17.0.0",
 		"@wordpress/blocks": "^15.27.0",
 		"@wordpress/commands": "^1.54.0",
+		"@wordpress/components": "^40.0.0",
 		"@wordpress/edit-post": "^8.54.0",
 		"@wordpress/element": "^8.6.0",
 		"@wordpress/i18n": "^6.27.0",

--- a/src/lib/abilities.ts
+++ b/src/lib/abilities.ts
@@ -5,7 +5,8 @@ export type JsonSchema = {
 	title?: string;
 	description?: string;
 	properties?: Record<string, JsonSchema>;
-	items?: JsonSchema;
+	// Core keeps a draft-04 tuple as an array of schemas, one per slot.
+	items?: JsonSchema | JsonSchema[];
 	enum?: unknown[];
 	required?: string[];
 	default?: unknown;

--- a/src/lib/schema-form.ts
+++ b/src/lib/schema-form.ts
@@ -1,0 +1,520 @@
+// An ability's `input_schema` turned into controls to render. No WP imports, so
+// `node --test` covers this rather than an assertion on rendered copy.
+//
+// Core's `wp_prepare_json_schema_for_client` folds a draft-03 per-property
+// `required: true` into an array on the parent, and passes alternation through.
+
+import type { JsonSchema } from "./abilities";
+
+// Codes, not sentences: every one of these is rendered translated.
+export type UnsupportedReason =
+	| "alternatives"
+	| "tuple"
+	| "freeform"
+	| "untyped"
+	| "mixed-types";
+
+export type FieldError =
+	| { code: "required" }
+	| { code: "min-length"; limit: number }
+	| { code: "max-length"; limit: number }
+	| { code: "pattern" }
+	| { code: "not-a-number" }
+	| { code: "not-an-integer" }
+	| { code: "minimum"; limit: number; exclusive: boolean }
+	| { code: "maximum"; limit: number; exclusive: boolean }
+	| { code: "min-items"; limit: number }
+	| { code: "max-items"; limit: number };
+
+// `value` is kept beside the string so a numeric or boolean enum survives the DOM.
+export type Option = { key: string; label: string; value: unknown };
+
+type Control =
+	| {
+			control: "text";
+			inputType: "text" | "email" | "url";
+			minLength?: number;
+			maxLength?: number;
+			pattern?: string;
+	  }
+	| {
+			control: "number";
+			integer: boolean;
+			minimum?: number;
+			maximum?: number;
+			exclusiveMinimum?: boolean;
+			exclusiveMaximum?: boolean;
+	  }
+	| { control: "toggle" }
+	| { control: "select"; options: Option[] }
+	| {
+			control: "checkboxes";
+			options: Option[];
+			minItems?: number;
+			maxItems?: number;
+	  }
+	| { control: "list"; item: Field; minItems?: number; maxItems?: number }
+	| { control: "group"; fields: Field[] }
+	| { control: "unsupported"; reason: UnsupportedReason };
+
+export type Field = Control & {
+	key: string;
+	// An empty path means the whole input is this field's value.
+	path: string[];
+	label: string;
+	description?: string;
+	required: boolean;
+	defaultValue?: unknown;
+};
+
+export type Form = {
+	fields: Field[];
+	// A schema no form can show, as opposed to one field that cannot.
+	unsupported: UnsupportedReason | null;
+	defaultValue?: unknown;
+};
+
+// Stands in for a row index until a row exists to number.
+const ITEM_INDEX = "*";
+
+// No property path can produce this, so the root field collides with nothing.
+const ROOT_KEY = "$";
+
+const ALTERNATION = ["anyOf", "oneOf", "allOf", "not", "$ref"];
+
+const INPUT_TYPES: Record<string, "email" | "url"> = {
+	email: "email",
+	uri: "url",
+};
+
+const pathKey = (path: readonly string[]) => path.join(".") || ROOT_KEY;
+
+// Property names are not translatable, so this is the only label they can have.
+const humanize = (key: string) => {
+	const spaced = key
+		.replace(/[_-]+/g, " ")
+		.replace(/([a-z\d])([A-Z])/g, "$1 $2")
+		.trim();
+
+	return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+};
+
+const finite = (value: unknown) =>
+	typeof value === "number" && Number.isFinite(value) ? value : undefined;
+
+const count = (value: unknown) => {
+	const found = finite(value);
+	return found !== undefined && found >= 0 ? Math.floor(found) : undefined;
+};
+
+type Resolved =
+	| { type: string; nullable: boolean }
+	| { reason: UnsupportedReason };
+
+const resolveType = (schema: JsonSchema): Resolved => {
+	if (ALTERNATION.some((keyword) => schema[keyword] !== undefined)) {
+		return { reason: "alternatives" };
+	}
+
+	const declared = Array.isArray(schema.type)
+		? schema.type
+		: schema.type
+			? [schema.type]
+			: [];
+	// `['string', 'null']` is an optional string, not two kinds of value.
+	const types = declared.filter((type) => type !== "null");
+	const nullable = types.length !== declared.length;
+
+	if (types.length > 1) return { reason: "mixed-types" };
+	if (types.length === 1) return { type: types[0], nullable };
+	// An enum says what the values are even when nothing says what type they are.
+	if (Array.isArray(schema.enum) && schema.enum.length) {
+		return { type: "enum", nullable };
+	}
+
+	return { reason: "untyped" };
+};
+
+const enumOptions = (schema: JsonSchema): Option[] | null => {
+	if (!Array.isArray(schema.enum) || !schema.enum.length) return null;
+
+	return schema.enum.map((value) => ({
+		key: JSON.stringify(value) ?? String(value),
+		label: String(value),
+		value,
+	}));
+};
+
+type Base = Omit<Field, keyof Control> & { control?: never };
+
+const itemBounds = (schema: JsonSchema) => ({
+	minItems: count(schema.minItems),
+	maxItems: count(schema.maxItems),
+});
+
+const arrayField = (base: Base, schema: JsonSchema): Field => {
+	const { items } = schema;
+	// A tuple `items` is one control per slot, which is not a repeater of one.
+	if (Array.isArray(items)) {
+		return { ...base, control: "unsupported", reason: "tuple" };
+	}
+	if (!items || typeof items !== "object") {
+		return { ...base, control: "unsupported", reason: "untyped" };
+	}
+
+	const options = enumOptions(items);
+	// The only array shape core ships: a set picked from a fixed list.
+	if (options) {
+		return { ...base, control: "checkboxes", options, ...itemBounds(schema) };
+	}
+
+	return {
+		...base,
+		control: "list",
+		// A row that exists holds a value, whatever the array's own rules say.
+		item: toField(items, [...base.path, ITEM_INDEX], base.label, true),
+		...itemBounds(schema),
+	};
+};
+
+const objectFields = (schema: JsonSchema, path: readonly string[]): Field[] => {
+	const { properties } = schema;
+	if (!properties || typeof properties !== "object") return [];
+
+	const required = new Set(
+		Array.isArray(schema.required)
+			? schema.required.filter(
+					(name): name is string => typeof name === "string",
+				)
+			: [],
+	);
+
+	return Object.entries(properties).map(([name, child]) =>
+		toField(child, [...path, name], humanize(name), required.has(name)),
+	);
+};
+
+const objectField = (base: Base, schema: JsonSchema): Field => {
+	// Without `properties` there is no key to put a label on.
+	if (!schema.properties || typeof schema.properties !== "object") {
+		return { ...base, control: "unsupported", reason: "freeform" };
+	}
+
+	return { ...base, control: "group", fields: objectFields(schema, base.path) };
+};
+
+const toField = (
+	schema: JsonSchema,
+	path: string[],
+	label: string,
+	required: boolean,
+): Field => {
+	const base: Base = {
+		key: pathKey(path),
+		path,
+		label: schema.title ?? label,
+		description:
+			typeof schema.description === "string" ? schema.description : undefined,
+		required,
+		defaultValue: schema.default,
+	};
+
+	const resolved = resolveType(schema);
+	if ("reason" in resolved) {
+		return { ...base, control: "unsupported", reason: resolved.reason };
+	}
+
+	const options = enumOptions(schema);
+	if (options) return { ...base, control: "select", options };
+
+	switch (resolved.type) {
+		case "boolean":
+			return { ...base, control: "toggle" };
+		case "integer":
+		case "number":
+			return {
+				...base,
+				control: "number",
+				integer: resolved.type === "integer",
+				minimum: finite(schema.minimum),
+				maximum: finite(schema.maximum),
+				// draft-04 spells these as flags on `minimum` / `maximum`.
+				exclusiveMinimum: schema.exclusiveMinimum === true,
+				exclusiveMaximum: schema.exclusiveMaximum === true,
+			};
+		case "string":
+			return {
+				...base,
+				control: "text",
+				inputType:
+					INPUT_TYPES[typeof schema.format === "string" ? schema.format : ""] ??
+					"text",
+				minLength: count(schema.minLength),
+				maxLength: count(schema.maxLength),
+				pattern:
+					typeof schema.pattern === "string" ? schema.pattern : undefined,
+			};
+		case "array":
+			return arrayField(base, schema);
+		case "object":
+			return objectField(base, schema);
+		default:
+			return { ...base, control: "unsupported", reason: "untyped" };
+	}
+};
+
+export const toForm = (
+	schema: JsonSchema | undefined,
+	fallbackLabel = "",
+): Form => {
+	// An ability with no input leaves the schema empty, and core sends `[]`.
+	if (!schema || !Object.keys(schema).length) {
+		return { fields: [], unsupported: null };
+	}
+
+	const resolved = resolveType(schema);
+	if ("reason" in resolved) return { fields: [], unsupported: resolved.reason };
+
+	if (resolved.type === "object") {
+		if (!schema.properties || typeof schema.properties !== "object") {
+			return { fields: [], unsupported: "freeform" };
+		}
+
+		return {
+			fields: objectFields(schema, []),
+			unsupported: null,
+			defaultValue: schema.default,
+		};
+	}
+
+	// The run route takes the whole input as one value, so this is one field.
+	return {
+		fields: [
+			toField(
+				schema,
+				[],
+				schema.title ?? fallbackLabel,
+				!("default" in schema) && !resolved.nullable,
+			),
+		],
+		unsupported: null,
+		defaultValue: schema.default,
+	};
+};
+
+export const readAt = (input: unknown, path: readonly string[]): unknown => {
+	let current = input;
+	for (const segment of path) {
+		if (current === null || typeof current !== "object") return undefined;
+		current = (current as Record<string, unknown>)[segment];
+	}
+
+	return current;
+};
+
+export const writeAt = (
+	input: unknown,
+	path: readonly string[],
+	value: unknown,
+): unknown => {
+	if (!path.length) return value;
+
+	const [segment, ...rest] = path;
+	// An index segment means the level holding it is a list, not an object.
+	if (/^\d+$/.test(segment)) {
+		const list = Array.isArray(input) ? [...input] : [];
+		// Clamped because a hole left in the array would be sent as null.
+		const at = Math.min(Number(segment), list.length);
+		list[at] = writeAt(list[at], rest, value);
+		return list;
+	}
+
+	const object =
+		input !== null && typeof input === "object" && !Array.isArray(input)
+			? { ...(input as Record<string, unknown>) }
+			: {};
+	object[segment] = writeAt(object[segment], rest, value);
+
+	return object;
+};
+
+// Leftmost only, so an inner list keeps its own once the outer row is numbered.
+const fillIndex = (field: Field, index: string): Field => {
+	const at = field.path.indexOf(ITEM_INDEX);
+	if (at === -1) return field;
+
+	const path = [...field.path];
+	path[at] = index;
+	const next = { ...field, path, key: pathKey(path) };
+
+	if (next.control === "group") {
+		return {
+			...next,
+			fields: next.fields.map((child) => fillIndex(child, index)),
+		};
+	}
+	if (next.control === "list") {
+		return { ...next, item: fillIndex(next.item, index) };
+	}
+
+	return next;
+};
+
+export const itemField = (item: Field, index: number) =>
+	fillIndex(item, String(index));
+
+export const emptyValue = (field: Field): unknown => {
+	switch (field.control) {
+		case "group":
+			return {};
+		case "list":
+		case "checkboxes":
+			return [];
+		case "toggle":
+			return false;
+		default:
+			return "";
+	}
+};
+
+const seed = (field: Field, input: unknown): unknown => {
+	if (field.control === "group") {
+		let next = input;
+		for (const child of field.fields) next = seed(child, next);
+		return next;
+	}
+	if (field.defaultValue === undefined) return input;
+	if (readAt(input, field.path) !== undefined) return input;
+
+	return writeAt(input, field.path, field.defaultValue);
+};
+
+export const initialInput = (form: Form): unknown => {
+	let input = form.defaultValue;
+	for (const field of form.fields) input = seed(field, input);
+
+	return input;
+};
+
+// `false` and `0` are answers; only an absent one is unfilled.
+const isBlank = (value: unknown) =>
+	value === undefined || value === null || value === "";
+
+const matchesPattern = (pattern: string, value: string) => {
+	try {
+		return new RegExp(pattern).test(value);
+	} catch {
+		// An unusable pattern is the schema author's problem, not the user's.
+		return true;
+	}
+};
+
+const textError = (
+	field: Field & { control: "text" },
+	value: unknown,
+): FieldError | null => {
+	const text = String(value);
+	if (field.minLength !== undefined && text.length < field.minLength) {
+		return { code: "min-length", limit: field.minLength };
+	}
+	if (field.maxLength !== undefined && text.length > field.maxLength) {
+		return { code: "max-length", limit: field.maxLength };
+	}
+	if (field.pattern && !matchesPattern(field.pattern, text)) {
+		return { code: "pattern" };
+	}
+
+	return null;
+};
+
+const numberError = (
+	field: Field & { control: "number" },
+	value: unknown,
+): FieldError | null => {
+	const found = typeof value === "number" ? value : Number(value);
+	if (!Number.isFinite(found)) return { code: "not-a-number" };
+	if (field.integer && !Number.isInteger(found)) {
+		return { code: "not-an-integer" };
+	}
+
+	const { minimum, maximum, exclusiveMinimum, exclusiveMaximum } = field;
+	if (
+		minimum !== undefined &&
+		(exclusiveMinimum ? found <= minimum : found < minimum)
+	) {
+		return { code: "minimum", limit: minimum, exclusive: !!exclusiveMinimum };
+	}
+	if (
+		maximum !== undefined &&
+		(exclusiveMaximum ? found >= maximum : found > maximum)
+	) {
+		return { code: "maximum", limit: maximum, exclusive: !!exclusiveMaximum };
+	}
+
+	return null;
+};
+
+const countError = (
+	field: Field & { control: "list" | "checkboxes" },
+	length: number,
+): FieldError | null => {
+	if (field.required && !length) return { code: "required" };
+	// An untouched optional list is empty, not short.
+	if (length && field.minItems !== undefined && length < field.minItems) {
+		return { code: "min-items", limit: field.minItems };
+	}
+	if (field.maxItems !== undefined && length > field.maxItems) {
+		return { code: "max-items", limit: field.maxItems };
+	}
+
+	return null;
+};
+
+const collect = (
+	field: Field,
+	input: unknown,
+	errors: Record<string, FieldError>,
+) => {
+	if (field.control === "group") {
+		for (const child of field.fields) collect(child, input, errors);
+		return;
+	}
+	if (field.control === "unsupported") return;
+
+	const value = readAt(input, field.path);
+
+	if (field.control === "list" || field.control === "checkboxes") {
+		const list = Array.isArray(value) ? value : [];
+		const error = countError(field, list.length);
+		if (error) {
+			errors[field.key] = error;
+			return;
+		}
+		if (field.control === "list") {
+			for (const [index] of list.entries()) {
+				collect(itemField(field.item, index), input, errors);
+			}
+		}
+		return;
+	}
+
+	if (isBlank(value)) {
+		if (field.required) errors[field.key] = { code: "required" };
+		return;
+	}
+
+	const error =
+		field.control === "text"
+			? textError(field, value)
+			: field.control === "number"
+				? numberError(field, value)
+				: null;
+	if (error) errors[field.key] = error;
+};
+
+export const fieldErrors = (form: Form, input: unknown) => {
+	const errors: Record<string, FieldError> = {};
+	for (const field of form.fields) collect(field, input, errors);
+
+	return errors;
+};

--- a/src/palette/ability-form.tsx
+++ b/src/palette/ability-form.tsx
@@ -1,0 +1,423 @@
+import {
+	Button,
+	CheckboxControl,
+	Notice,
+	SelectControl,
+	TextControl,
+	ToggleControl,
+} from "@wordpress/components";
+import {
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from "@wordpress/element";
+import { __, _n, isRTL, sprintf } from "@wordpress/i18n";
+import { chevronLeft, chevronRight, closeSmall } from "@wordpress/icons";
+import type { Ability } from "../lib/abilities";
+import {
+	emptyValue,
+	type Field,
+	type FieldError,
+	fieldErrors,
+	initialInput,
+	itemField,
+	type Option,
+	readAt,
+	toForm,
+	type UnsupportedReason,
+	writeAt,
+} from "../lib/schema-form";
+
+type Setter = (path: string[], value: unknown) => void;
+
+const reasonText = (reason: UnsupportedReason) => {
+	switch (reason) {
+		case "alternatives":
+			return __(
+				"This input accepts alternatives that cannot be shown as a form.",
+				"command-palette-tools",
+			);
+		case "tuple":
+			return __(
+				"This input is an ordered list of different values, which cannot be shown as a form.",
+				"command-palette-tools",
+			);
+		case "freeform":
+			return __(
+				"This input accepts values that cannot be named in advance.",
+				"command-palette-tools",
+			);
+		case "mixed-types":
+			return __(
+				"This input accepts more than one kind of value.",
+				"command-palette-tools",
+			);
+		default:
+			return __(
+				"This input does not say what kind of value it takes.",
+				"command-palette-tools",
+			);
+	}
+};
+
+const errorText = (error: FieldError) => {
+	switch (error.code) {
+		case "required":
+			return __("This field is required.", "command-palette-tools");
+		case "min-length":
+			return sprintf(
+				/* translators: %d: the fewest characters the value may have. */
+				_n(
+					"Use at least %d character.",
+					"Use at least %d characters.",
+					error.limit,
+					"command-palette-tools",
+				),
+				error.limit,
+			);
+		case "max-length":
+			return sprintf(
+				/* translators: %d: the most characters the value may have. */
+				_n(
+					"Use no more than %d character.",
+					"Use no more than %d characters.",
+					error.limit,
+					"command-palette-tools",
+				),
+				error.limit,
+			);
+		case "pattern":
+			return __(
+				"This value is not in the expected format.",
+				"command-palette-tools",
+			);
+		case "not-a-number":
+			return __("Enter a number.", "command-palette-tools");
+		case "not-an-integer":
+			return __("Enter a whole number.", "command-palette-tools");
+		case "minimum":
+			return error.exclusive
+				? sprintf(
+						/* translators: %s: a number the value has to exceed. */
+						__("Enter a number greater than %s.", "command-palette-tools"),
+						String(error.limit),
+					)
+				: sprintf(
+						/* translators: %s: the lowest number allowed. */
+						__("Enter %s or more.", "command-palette-tools"),
+						String(error.limit),
+					);
+		case "maximum":
+			return error.exclusive
+				? sprintf(
+						/* translators: %s: a number the value has to stay below. */
+						__("Enter a number less than %s.", "command-palette-tools"),
+						String(error.limit),
+					)
+				: sprintf(
+						/* translators: %s: the highest number allowed. */
+						__("Enter %s or less.", "command-palette-tools"),
+						String(error.limit),
+					);
+		case "min-items":
+			return sprintf(
+				/* translators: %d: the fewest values that may be given. */
+				_n(
+					"Provide at least %d value.",
+					"Provide at least %d values.",
+					error.limit,
+					"command-palette-tools",
+				),
+				error.limit,
+			);
+		default:
+			return sprintf(
+				/* translators: %d: the most values that may be given. */
+				_n(
+					"Provide no more than %d value.",
+					"Provide no more than %d values.",
+					error.limit,
+					"command-palette-tools",
+				),
+				error.limit,
+			);
+	}
+};
+
+const labelText = (field: Field, override?: string) => {
+	const label = override ?? field.label;
+	if (!field.required) return label;
+
+	return sprintf(
+		/* translators: %s: the name of a form field that has to be filled in. */
+		__("%s (required)", "command-palette-tools"),
+		label,
+	);
+};
+
+const asText = (value: unknown) =>
+	value === undefined || value === null ? "" : String(value);
+
+const optionValue = (options: Option[], key: string) =>
+	options.find((option) => option.key === key)?.value;
+
+const optionKey = (options: Option[], value: unknown) =>
+	options.find((option) => option.value === value)?.key ?? "";
+
+const FieldRow = ({
+	field,
+	input,
+	errors,
+	set,
+	label,
+}: {
+	field: Field;
+	input: unknown;
+	errors: Record<string, FieldError>;
+	set: Setter;
+	label?: string;
+}) => {
+	const value = readAt(input, field.path);
+	const error = errors[field.key];
+	const help = error ? errorText(error) : field.description;
+
+	switch (field.control) {
+		case "text":
+			return (
+				<TextControl
+					__nextHasNoMarginBottom
+					label={labelText(field, label)}
+					type={field.inputType}
+					value={asText(value)}
+					minLength={field.minLength}
+					maxLength={field.maxLength}
+					help={help}
+					onChange={(next) => set(field.path, next)}
+				/>
+			);
+		case "number":
+			return (
+				<TextControl
+					__nextHasNoMarginBottom
+					label={labelText(field, label)}
+					type="number"
+					// Kept as typed: parsing per keystroke eats a half-written "1.5".
+					value={asText(value)}
+					min={field.minimum}
+					max={field.maximum}
+					step={field.integer ? 1 : "any"}
+					help={help}
+					onChange={(next) => set(field.path, next)}
+				/>
+			);
+		case "toggle":
+			return (
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={labelText(field, label)}
+					checked={value === true}
+					help={help}
+					onChange={(next) => set(field.path, next)}
+				/>
+			);
+		case "select":
+			return (
+				<SelectControl
+					__nextHasNoMarginBottom
+					label={labelText(field, label)}
+					value={optionKey(field.options, value)}
+					options={[
+						...(field.required
+							? []
+							: [
+									{
+										label: __("Not set", "command-palette-tools"),
+										value: "",
+									},
+								]),
+						...field.options.map((option) => ({
+							label: option.label,
+							value: option.key,
+						})),
+					]}
+					help={help}
+					onChange={(key) => set(field.path, optionValue(field.options, key))}
+				/>
+			);
+		case "checkboxes": {
+			const picked = Array.isArray(value) ? value : [];
+			const isPicked = (option: Option) =>
+				picked.some((entry) => entry === option.value);
+
+			return (
+				<fieldset className="wpcp-tools-palette__fieldset">
+					<legend>{labelText(field, label)}</legend>
+					{field.options.map((option) => (
+						<CheckboxControl
+							__nextHasNoMarginBottom
+							key={option.key}
+							label={option.label}
+							checked={isPicked(option)}
+							onChange={(checked) =>
+								// Rebuilt from the schema's order, so ticks do not reorder it.
+								set(
+									field.path,
+									field.options
+										.filter((candidate) =>
+											candidate.key === option.key
+												? checked
+												: isPicked(candidate),
+										)
+										.map((candidate) => candidate.value),
+								)
+							}
+						/>
+					))}
+					{help && <p className="wpcp-tools-palette__help">{help}</p>}
+				</fieldset>
+			);
+		}
+		case "list": {
+			const rows = Array.isArray(value) ? value : [];
+			const full =
+				field.maxItems !== undefined && rows.length >= field.maxItems;
+
+			return (
+				<fieldset className="wpcp-tools-palette__fieldset">
+					<legend>{labelText(field, label)}</legend>
+					{rows.map((_row, index) => {
+						const row = itemField(field.item, index);
+
+						return (
+							<div className="wpcp-tools-palette__row" key={row.key}>
+								<FieldRow
+									field={row}
+									input={input}
+									errors={errors}
+									set={set}
+									label={sprintf(
+										/* translators: 1: the name of a list of values, 2: which one this is. */
+										__("%1$s %2$d", "command-palette-tools"),
+										field.label,
+										index + 1,
+									)}
+								/>
+								<Button
+									icon={closeSmall}
+									label={__("Remove", "command-palette-tools")}
+									onClick={() =>
+										set(
+											field.path,
+											rows.filter((_row, at) => at !== index),
+										)
+									}
+								/>
+							</div>
+						);
+					})}
+					{help && <p className="wpcp-tools-palette__help">{help}</p>}
+					<Button
+						variant="secondary"
+						disabled={full}
+						onClick={() => set(field.path, [...rows, emptyValue(field.item)])}
+					>
+						{__("Add", "command-palette-tools")}
+					</Button>
+				</fieldset>
+			);
+		}
+		case "group":
+			return (
+				<fieldset className="wpcp-tools-palette__fieldset">
+					<legend>{labelText(field, label)}</legend>
+					{field.description && (
+						<p className="wpcp-tools-palette__help">{field.description}</p>
+					)}
+					{field.fields.map((child) => (
+						<FieldRow
+							key={child.key}
+							field={child}
+							input={input}
+							errors={errors}
+							set={set}
+						/>
+					))}
+				</fieldset>
+			);
+		default:
+			return (
+				<TextControl
+					__nextHasNoMarginBottom
+					disabled
+					label={labelText(field, label)}
+					value=""
+					help={reasonText(field.reason)}
+					onChange={() => undefined}
+				/>
+			);
+	}
+};
+
+export const AbilityForm = ({
+	ability,
+	onBack,
+}: {
+	ability: Ability;
+	onBack: () => void;
+}) => {
+	const form = useMemo(
+		() => toForm(ability.input_schema, ability.label),
+		[ability],
+	);
+	const [input, setInput] = useState<unknown>(() => initialInput(form));
+	const errors = fieldErrors(form, input);
+	const container = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		container.current?.querySelector<HTMLElement>("input, select")?.focus();
+	}, []);
+
+	const set = useCallback<Setter>(
+		(path, value) =>
+			setInput((current: unknown) => writeAt(current, path, value)),
+		[],
+	);
+
+	return (
+		<div className="wpcp-tools-palette__form" ref={container}>
+			<div className="wpcp-tools-palette__form-header">
+				<Button
+					icon={isRTL() ? chevronRight : chevronLeft}
+					label={__("Back to results", "command-palette-tools")}
+					onClick={onBack}
+				/>
+				<h2>{ability.label}</h2>
+			</div>
+			{ability.description && (
+				<p className="wpcp-tools-palette__help">{ability.description}</p>
+			)}
+			{form.unsupported ? (
+				<Notice status="warning" isDismissible={false}>
+					{reasonText(form.unsupported)}
+				</Notice>
+			) : (
+				form.fields.map((field) => (
+					<FieldRow
+						key={field.key}
+						field={field}
+						input={input}
+						errors={errors}
+						set={set}
+					/>
+				))
+			)}
+			{!form.unsupported && !form.fields.length && (
+				<p className="wpcp-tools-palette__help">
+					{__("This ability takes no input.", "command-palette-tools")}
+				</p>
+			)}
+		</div>
+	);
+};

--- a/src/palette/palette-menu.tsx
+++ b/src/palette/palette-menu.tsx
@@ -26,6 +26,7 @@ import {
 	type ToolCommand,
 } from "../lib/tool-commands";
 import { fireNotice } from "../lib/wordpress";
+import { AbilityForm } from "./ability-form";
 import { NOTICE_CONTEXT } from "./palette-notices";
 import { recents } from "./recents-store";
 import { useOpenPalette } from "./use-open-palette";
@@ -107,6 +108,7 @@ export const PaletteMenu = () => {
 	const [search, setSearch] = useState("");
 	const [catalog, setCatalog] = useState<Catalog | null>(null);
 	const [recent, setRecent] = useState(recents.list);
+	const [picked, setPicked] = useState<Ability | null>(null);
 
 	const input = useRef<HTMLInputElement>(null);
 
@@ -115,13 +117,21 @@ export const PaletteMenu = () => {
 
 	const close = useCallback(() => {
 		setSearch("");
+		setPicked(null);
 		setIsOpen(false);
 	}, []);
 
+	// Modal routes Escape here, so without this a form's Escape closes it all.
+	const requestClose = useCallback(() => {
+		if (picked) return setPicked(null);
+		close();
+	}, [close, picked]);
+
 	// Modal focuses its frame, not the search field, so typing would go nowhere.
 	useEffect(() => {
+		if (picked) return;
 		input.current?.focus();
-	}, [isOpen]);
+	}, [isOpen, picked]);
 
 	// Admin-wide, so fetching on mount would hit every admin page load.
 	useEffect(() => {
@@ -144,14 +154,10 @@ export const PaletteMenu = () => {
 		[close],
 	);
 
-	const selectAbility = useCallback(
-		(ability: Ability) => {
-			setRecent(recents.remember(ability.name));
-			// Nothing runs an ability yet.
-			close();
-		},
-		[close],
-	);
+	const selectAbility = useCallback((ability: Ability) => {
+		setRecent(recents.remember(ability.name));
+		setPicked(ability);
+	}, []);
 
 	// Math and colour are computed from the query, so never scored against it.
 	const tools = useMemo<Result[]>(
@@ -205,7 +211,7 @@ export const PaletteMenu = () => {
 	const count = tools.length + recentResults.length + otherResults.length;
 
 	useEffect(() => {
-		if (!isOpen || state === null) return;
+		if (!isOpen || picked || state === null) return;
 
 		// Waits out the keystroke so a screen reader announces one total, not six.
 		const timer = setTimeout(() => {
@@ -223,7 +229,7 @@ export const PaletteMenu = () => {
 			);
 		}, 500);
 		return () => clearTimeout(timer);
-	}, [count, isOpen, state]);
+	}, [count, isOpen, picked, state]);
 
 	if (!isOpen) return null;
 
@@ -233,53 +239,61 @@ export const PaletteMenu = () => {
 		<Modal
 			className="commands-command-menu wpcp-tools-palette"
 			overlayClassName="commands-command-menu__overlay"
-			onRequestClose={close}
+			onRequestClose={requestClose}
 			__experimentalHideHeader
 			size="medium"
 			contentLabel={__("Ability palette", "command-palette-tools")}
 		>
-			<div className="commands-command-menu__container">
-				<Command
-					label={__("Search abilities", "command-palette-tools")}
-					shouldFilter={false}
-					loop
-				>
-					<div className="commands-command-menu__header">
-						<Icon
-							className="commands-command-menu__header-search-icon"
-							icon={searchIcon}
-						/>
-						<Command.Input
-							ref={input}
-							value={search}
-							onValueChange={setSearch}
-							placeholder={__("Search abilities", "command-palette-tools")}
-						/>
-					</div>
-					<Command.List label={__("Results", "command-palette-tools")}>
-						{state === null && (
-							<Command.Loading>
-								{__("Loading abilities…", "command-palette-tools")}
-							</Command.Loading>
-						)}
-						<ResultGroup
-							heading={__("Recent", "command-palette-tools")}
-							results={recentResults}
-						/>
-						<ResultGroup
-							heading={__("Tools", "command-palette-tools")}
-							results={tools}
-						/>
-						<ResultGroup
-							heading={__("Abilities", "command-palette-tools")}
-							results={otherResults}
-						/>
-						{message && (
-							<div className="wpcp-tools-palette__notice">{message}</div>
-						)}
-					</Command.List>
-				</Command>
-			</div>
+			{picked ? (
+				<AbilityForm
+					key={picked.name}
+					ability={picked}
+					onBack={() => setPicked(null)}
+				/>
+			) : (
+				<div className="commands-command-menu__container">
+					<Command
+						label={__("Search abilities", "command-palette-tools")}
+						shouldFilter={false}
+						loop
+					>
+						<div className="commands-command-menu__header">
+							<Icon
+								className="commands-command-menu__header-search-icon"
+								icon={searchIcon}
+							/>
+							<Command.Input
+								ref={input}
+								value={search}
+								onValueChange={setSearch}
+								placeholder={__("Search abilities", "command-palette-tools")}
+							/>
+						</div>
+						<Command.List label={__("Results", "command-palette-tools")}>
+							{state === null && (
+								<Command.Loading>
+									{__("Loading abilities…", "command-palette-tools")}
+								</Command.Loading>
+							)}
+							<ResultGroup
+								heading={__("Recent", "command-palette-tools")}
+								results={recentResults}
+							/>
+							<ResultGroup
+								heading={__("Tools", "command-palette-tools")}
+								results={tools}
+							/>
+							<ResultGroup
+								heading={__("Abilities", "command-palette-tools")}
+								results={otherResults}
+							/>
+							{message && (
+								<div className="wpcp-tools-palette__notice">{message}</div>
+							)}
+						</Command.List>
+					</Command>
+				</div>
+			)}
 		</Modal>
 	);
 };

--- a/src/palette/palette.css
+++ b/src/palette/palette.css
@@ -26,3 +26,62 @@
 	left: 16px;
 	z-index: 100000;
 }
+
+/* Core pads its command container, not the modal, so a form sits flush. */
+/* no-prefix */
+.wpcp-tools-palette__form {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+	padding: 16px;
+	max-height: 70vh;
+	overflow-y: auto;
+}
+
+/* no-prefix */
+.wpcp-tools-palette__form-header {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+}
+
+/* no-prefix */
+.wpcp-tools-palette__form-header h2 {
+	margin: 0;
+	font-size: 15px;
+}
+
+/* no-prefix */
+.wpcp-tools-palette__fieldset {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	margin: 0;
+	border: 1px solid #ddd;
+	padding: 12px;
+}
+
+/* no-prefix */
+.wpcp-tools-palette__fieldset legend {
+	padding: 0 4px;
+	font-weight: 600;
+}
+
+/* no-prefix */
+.wpcp-tools-palette__row {
+	display: flex;
+	align-items: flex-end;
+	gap: 4px;
+}
+
+/* no-prefix */
+.wpcp-tools-palette__row > *:first-child {
+	flex-grow: 1;
+}
+
+/* no-prefix */
+.wpcp-tools-palette__help {
+	margin: 0;
+	color: #757575;
+	font-size: 12px;
+}

--- a/tests/palette.spec.ts
+++ b/tests/palette.spec.ts
@@ -128,7 +128,8 @@ test("an ability picked once comes back under Recent", async ({
 
 	const palette = page.getByRole("dialog", { name: "Ability palette" });
 	await palette.getByRole("option", { name: /Get User Information/ }).click();
-	await expect(palette).toBeHidden();
+	// Picking opens the ability's form, so the palette stays up.
+	await expect(palette.getByRole("group", { name: "Fields" })).toBeVisible();
 
 	await admin.visitAdminPage("options-general.php");
 	await page.keyboard.press(`${modifier}+j`);
@@ -137,4 +138,50 @@ test("an ability picked once comes back under Recent", async ({
 	await expect(palette.getByRole("option").first()).toContainText(
 		"Get User Information",
 	);
+});
+
+test("picking an ability opens a form built from its input schema", async ({
+	admin,
+	page,
+}) => {
+	await admin.visitAdminPage("plugins.php");
+	await page.keyboard.press(`${modifier}+j`);
+
+	const palette = page.getByRole("dialog", { name: "Ability palette" });
+	await palette.getByRole("option", { name: /Get Site Information/ }).click();
+
+	await expect(
+		palette.getByRole("heading", { name: "Get Site Information" }),
+	).toBeVisible();
+	// Core's only input is an array of the field names it will return.
+	const fields = palette.getByRole("group", { name: "Fields" });
+	await expect(fields.getByRole("checkbox")).toHaveCount(8);
+	for (const name of ["name", "url", "wpurl", "admin_email", "version"]) {
+		// "url" is a prefix of "wpurl", so a loose name matches two rows.
+		await expect(
+			fields.getByRole("checkbox", { name, exact: true }),
+		).toBeVisible();
+	}
+
+	const language = fields.getByRole("checkbox", { name: "language" });
+	await language.check();
+	await expect(language).toBeChecked();
+});
+
+test("Escape steps back out of a form before it closes the palette", async ({
+	admin,
+	page,
+}) => {
+	await admin.visitAdminPage("options-general.php");
+	await page.keyboard.press(`${modifier}+j`);
+
+	const palette = page.getByRole("dialog", { name: "Ability palette" });
+	await palette.getByRole("option", { name: /Get User Information/ }).click();
+	await expect(palette.getByRole("group", { name: "Fields" })).toBeVisible();
+
+	await page.keyboard.press("Escape");
+	await expect(palette.getByRole("option").first()).toBeVisible();
+
+	await page.keyboard.press("Escape");
+	await expect(palette).toBeHidden();
 });

--- a/tests/unit/schema-form.test.ts
+++ b/tests/unit/schema-form.test.ts
@@ -1,0 +1,404 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { JsonSchema } from "../../src/lib/abilities.ts";
+import {
+	type Field,
+	fieldErrors,
+	initialInput,
+	itemField,
+	readAt,
+	toForm,
+	writeAt,
+} from "../../src/lib/schema-form.ts";
+
+// What all three of core's abilities ship on WP 7.1.
+const CORE_SCHEMA: JsonSchema = {
+	type: "object",
+	properties: {
+		fields: {
+			type: "array",
+			items: { type: "string", enum: ["name", "url", "language"] },
+			description: "Optional: Limit response to specific fields.",
+		},
+	},
+	additionalProperties: false,
+	default: {},
+};
+
+const field = (form: { fields: Field[] }, key: string) => {
+	const found = form.fields.find((candidate) => candidate.key === key);
+	assert.ok(found, `no field keyed ${key}`);
+	return found;
+};
+
+describe("toForm", () => {
+	it("asks for nothing when the ability takes no input", () => {
+		assert.deepEqual(toForm({}), { fields: [], unsupported: null });
+		assert.deepEqual(toForm(undefined), { fields: [], unsupported: null });
+	});
+
+	it("turns core's array of allowed values into one set of checkboxes", () => {
+		const form = toForm(CORE_SCHEMA);
+		const fields = field(form, "fields");
+
+		assert.equal(form.unsupported, null);
+		assert.equal(fields.control, "checkboxes");
+		assert.equal(fields.label, "Fields");
+		assert.equal(fields.required, false);
+		assert.ok(fields.control === "checkboxes");
+		assert.deepEqual(
+			fields.options.map(({ value }) => value),
+			["name", "url", "language"],
+		);
+	});
+
+	it("picks a control per property type", () => {
+		const form = toForm({
+			type: "object",
+			properties: {
+				post_title: { type: "string", maxLength: 60 },
+				count: { type: "integer", minimum: 1 },
+				ratio: { type: "number" },
+				sticky: { type: "boolean" },
+				status: { type: "string", enum: ["draft", "publish"] },
+				owner: { type: "string", format: "email" },
+				tags: { type: "array", items: { type: "string" } },
+			},
+			required: ["post_title", "status"],
+		});
+
+		assert.equal(field(form, "post_title").control, "text");
+		assert.equal(field(form, "count").control, "number");
+		assert.equal(field(form, "ratio").control, "number");
+		assert.equal(field(form, "sticky").control, "toggle");
+		assert.equal(field(form, "status").control, "select");
+		assert.equal(field(form, "tags").control, "list");
+
+		const title = field(form, "post_title");
+		assert.equal(title.label, "Post title");
+		assert.equal(title.required, true);
+		assert.ok(title.control === "text");
+		assert.equal(title.maxLength, 60);
+
+		const count = field(form, "count");
+		assert.ok(count.control === "number");
+		assert.equal(count.integer, true);
+		assert.equal(count.minimum, 1);
+
+		const ratio = field(form, "ratio");
+		assert.ok(ratio.control === "number");
+		assert.equal(ratio.integer, false);
+
+		const owner = field(form, "owner");
+		assert.ok(owner.control === "text");
+		assert.equal(owner.inputType, "email");
+
+		assert.equal(field(form, "sticky").required, false);
+	});
+
+	it("nests an object into a group whose children carry the full path", () => {
+		const form = toForm({
+			type: "object",
+			properties: {
+				author: {
+					type: "object",
+					title: "Author",
+					properties: {
+						name: { type: "string" },
+						id: { type: "integer" },
+					},
+					required: ["name"],
+				},
+			},
+		});
+
+		const author = field(form, "author");
+		assert.equal(author.control, "group");
+		assert.equal(author.label, "Author");
+		assert.ok(author.control === "group");
+		assert.deepEqual(
+			author.fields.map(({ key, path, required }) => [key, path, required]),
+			[
+				["author.name", ["author", "name"], true],
+				["author.id", ["author", "id"], false],
+			],
+		);
+	});
+
+	it("makes a scalar schema the whole input", () => {
+		const form = toForm({ type: "string", minLength: 3 }, "Search term");
+		const [only] = form.fields;
+
+		assert.equal(form.fields.length, 1);
+		assert.deepEqual(only.path, []);
+		assert.equal(only.label, "Search term");
+		// Nothing else can carry the value, so it cannot be left out.
+		assert.equal(only.required, true);
+	});
+
+	it("does not require a scalar input the schema defaults", () => {
+		assert.equal(
+			toForm({ type: "string", default: "" }).fields[0].required,
+			false,
+		);
+		assert.equal(
+			toForm({ type: ["string", "null"] }).fields[0].required,
+			false,
+		);
+	});
+});
+
+describe("toForm, shapes no form can show", () => {
+	it("refuses a schema built from alternatives", () => {
+		assert.equal(
+			toForm({ oneOf: [{ type: "string" }, { type: "number" }] }).unsupported,
+			"alternatives",
+		);
+		assert.equal(
+			toForm({ $ref: "#/definitions/post" }).unsupported,
+			"alternatives",
+		);
+	});
+
+	it("refuses an object that names no properties", () => {
+		assert.equal(toForm({ type: "object" }).unsupported, "freeform");
+		assert.equal(
+			toForm({ type: "object", additionalProperties: true }).unsupported,
+			"freeform",
+		);
+	});
+
+	it("disables the one field it cannot show and keeps the rest", () => {
+		const form = toForm({
+			type: "object",
+			properties: {
+				title: { type: "string" },
+				either: { anyOf: [{ type: "string" }, { type: "integer" }] },
+				pair: {
+					type: "array",
+					items: [{ type: "string" }, { type: "integer" }],
+				},
+				anything: {},
+				both: { type: ["string", "integer"] },
+			},
+		});
+
+		assert.equal(form.unsupported, null);
+		assert.equal(field(form, "title").control, "text");
+		for (const [key, reason] of [
+			["either", "alternatives"],
+			["pair", "tuple"],
+			["anything", "untyped"],
+			["both", "mixed-types"],
+		]) {
+			const found = field(form, key);
+			assert.ok(found.control === "unsupported");
+			assert.equal(found.reason, reason);
+		}
+	});
+});
+
+describe("initialInput", () => {
+	it("starts from the schema's own defaults", () => {
+		assert.deepEqual(initialInput(toForm(CORE_SCHEMA)), {});
+		assert.deepEqual(
+			initialInput(
+				toForm({
+					type: "object",
+					properties: {
+						status: { type: "string", enum: ["draft"], default: "draft" },
+						sticky: { type: "boolean" },
+					},
+				}),
+			),
+			{ status: "draft" },
+		);
+	});
+
+	it("has nothing to fill in when no default is declared", () => {
+		assert.equal(initialInput(toForm({ type: "string" })), undefined);
+	});
+});
+
+describe("readAt and writeAt", () => {
+	it("writes a nested value without touching its siblings", () => {
+		const input = { author: { name: "Ann", id: 3 } };
+		const next = writeAt(input, ["author", "name"], "Bo");
+
+		assert.deepEqual(next, { author: { name: "Bo", id: 3 } });
+		assert.deepEqual(input, { author: { name: "Ann", id: 3 } });
+	});
+
+	it("builds a list where the path holds an index", () => {
+		assert.deepEqual(writeAt(undefined, ["tags", "0"], "a"), { tags: ["a"] });
+		assert.deepEqual(writeAt({ tags: ["a"] }, ["tags", "1"], "b"), {
+			tags: ["a", "b"],
+		});
+	});
+
+	it("leaves no hole when the index is past the end of the list", () => {
+		assert.deepEqual(writeAt(undefined, ["tags", "4"], "b"), { tags: ["b"] });
+	});
+
+	it("replaces the whole input for the empty path", () => {
+		assert.equal(writeAt({ a: 1 }, [], "scalar"), "scalar");
+		assert.equal(readAt("scalar", []), "scalar");
+	});
+
+	it("reads nothing through a value that is not an object", () => {
+		assert.equal(readAt({ a: 1 }, ["a", "b"]), undefined);
+	});
+});
+
+describe("itemField", () => {
+	it("numbers a row and everything under it", () => {
+		const form = toForm({
+			type: "object",
+			properties: {
+				authors: {
+					type: "array",
+					items: {
+						type: "object",
+						properties: { name: { type: "string" } },
+					},
+				},
+			},
+		});
+
+		const list = field(form, "authors");
+		assert.ok(list.control === "list");
+		const row = itemField(list.item, 2);
+
+		assert.deepEqual(row.path, ["authors", "2"]);
+		assert.equal(row.key, "authors.2");
+		assert.ok(row.control === "group");
+		assert.deepEqual(row.fields[0].path, ["authors", "2", "name"]);
+	});
+
+	it("leaves an inner list its own row number", () => {
+		const form = toForm({
+			type: "object",
+			properties: {
+				rows: {
+					type: "array",
+					items: { type: "array", items: { type: "string" } },
+				},
+			},
+		});
+
+		const outer = field(form, "rows");
+		assert.ok(outer.control === "list");
+		const row = itemField(outer.item, 0);
+		assert.ok(row.control === "list");
+
+		assert.deepEqual(itemField(row.item, 4).path, ["rows", "0", "4"]);
+	});
+});
+
+describe("fieldErrors", () => {
+	const form = toForm({
+		type: "object",
+		properties: {
+			title: { type: "string", minLength: 3, maxLength: 5 },
+			slug: { type: "string", pattern: "^[a-z]+$" },
+			broken: { type: "string", pattern: "^([a-z" },
+			count: { type: "integer", minimum: 1, maximum: 10 },
+			over: { type: "number", maximum: 10, exclusiveMaximum: true },
+			picks: {
+				type: "array",
+				items: { type: "string", enum: ["a", "b"] },
+				minItems: 2,
+			},
+		},
+		required: ["title", "picks"],
+	});
+
+	const codes = (input: unknown) =>
+		Object.fromEntries(
+			Object.entries(fieldErrors(form, input)).map(([key, error]) => [
+				key,
+				error.code,
+			]),
+		);
+
+	it("reports only what the schema requires when nothing is filled in", () => {
+		assert.deepEqual(codes({}), { title: "required", picks: "required" });
+	});
+
+	it("reports every rule the value breaks", () => {
+		assert.deepEqual(
+			codes({
+				title: "ab",
+				slug: "Nope",
+				count: 1.5,
+				over: 10,
+				picks: ["a"],
+			}),
+			{
+				title: "min-length",
+				slug: "pattern",
+				count: "not-an-integer",
+				over: "maximum",
+				picks: "min-items",
+			},
+		);
+	});
+
+	it("keeps a filled-in valid form clean", () => {
+		assert.deepEqual(
+			codes({
+				title: "abcd",
+				slug: "ok",
+				count: 10,
+				over: 9,
+				picks: ["a", "b"],
+			}),
+			{},
+		);
+	});
+
+	it("carries the limit a message has to print", () => {
+		assert.deepEqual(
+			fieldErrors(form, { title: "abcdef", picks: ["a", "b"] }),
+			{
+				title: { code: "max-length", limit: 5 },
+			},
+		);
+		assert.deepEqual(
+			fieldErrors(form, { title: "abc", picks: ["a", "b"], count: 0 }),
+			{
+				count: { code: "minimum", limit: 1, exclusive: false },
+			},
+		);
+	});
+
+	it("does not fail a value against a pattern that will not compile", () => {
+		assert.deepEqual(
+			codes({ title: "abc", picks: ["a", "b"], broken: "x" }),
+			{},
+		);
+	});
+
+	it("checks each row of a list on its own", () => {
+		const rows = toForm({
+			type: "object",
+			properties: {
+				tags: { type: "array", items: { type: "string", minLength: 2 } },
+			},
+		});
+
+		assert.deepEqual(fieldErrors(rows, { tags: ["ok", "x"] }), {
+			"tags.1": { code: "min-length", limit: 2 },
+		});
+	});
+
+	it("asks nothing of a field it cannot show", () => {
+		const unshowable = toForm({
+			type: "object",
+			properties: { either: { anyOf: [{ type: "string" }] } },
+			required: ["either"],
+		});
+
+		assert.deepEqual(fieldErrors(unshowable, {}), {});
+	});
+});


### PR DESCRIPTION
Picking an ability in the palette used to just close it. Now it opens a form built from whatever that ability says it accepts, with the right control for each value — a checkbox group for a fixed list of choices, a dropdown for a single choice, a text or number box, a switch, and a repeater for a list you add rows to.

Nothing runs yet; that is the next piece of work. What is here is the form and its checking: as you type, anything the ability would reject is explained under the field.

- Every ability WordPress ships takes the same one input — a tick list of which fields you want back — so that is the shape the form gets right first.
- Some abilities describe their input in ways no form can show, such as a value that could be any one of several different kinds. Those fields are greyed out with the reason instead of rendering something broken, and an ability whose whole input is like that says so rather than showing an empty form.
- Escape now steps back out of the form to the results, and only closes the palette from the list.
- The palette entry grows from 72KB to 85KB (25KB to 28KB over the wire). No new script loads: WordPress' own component library was already on the page.

_PR description generated by Claude._