### PR TITLE
Prove the palette stands up without core's

### DIFF
--- a/tests/no-core-palette/blueprint.json
+++ b/tests/no-core-palette/blueprint.json
@@ -1,0 +1,19 @@
+{
+	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
+	"login": false,
+	"steps": [
+		{ "step": "defineWpConfigConsts", "consts": { "WP_DEBUG": true } },
+		{
+			"step": "activatePlugin",
+			"pluginPath": "wp-command-palette-tools/command-palette-tools.php"
+		},
+		{
+			"step": "runPHP",
+			"code": "<?php $dir = '/wordpress/wp-content/mu-plugins'; if (!is_dir($dir)) mkdir($dir, 0777, true); copy('/wordpress/wp-content/plugins/wp-command-palette-tools/tests/no-core-palette/no-core-palette.php', $dir . '/no-core-palette.php'); ?>"
+		},
+		{
+			"step": "runPHP",
+			"code": "<?php require '/wordpress/wp-content/plugins/wp-command-palette-tools/tests/setup.php'; ?>"
+		}
+	]
+}

--- a/tests/no-core-palette/no-core-palette.php
+++ b/tests/no-core-palette/no-core-palette.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Plugin Name: No core command palette
+ * Description: Removes core's command palette from every admin screen.
+ *
+ * @package kevinbatdorf
+ */
+
+defined('ABSPATH') or die;
+
+remove_action('admin_enqueue_scripts', 'wp_enqueue_command_palette_assets');

--- a/tests/no-core-palette/no-core-palette.spec.ts
+++ b/tests/no-core-palette/no-core-palette.spec.ts
@@ -1,0 +1,62 @@
+import { expect, test } from "@wordpress/e2e-test-utils-playwright";
+
+const modifier = process.platform === "darwin" ? "Meta" : "Control";
+
+test.beforeEach(async ({ requestUtils, admin }) => {
+	await requestUtils.login();
+	await admin.visitAdminPage("plugins.php");
+});
+
+test("core's palette really is absent", async ({ page }) => {
+	// The control: every other suite runs with core's palette mounted.
+	expect(await page.evaluate(() => typeof window.wp?.commands)).toBe(
+		"undefined",
+	);
+
+	await page.keyboard.press(`${modifier}+k`);
+	await expect(
+		page.getByRole("dialog", { name: "Command palette" }),
+	).toBeHidden();
+});
+
+test("Cmd+K falls to us when nothing else claims it", async ({ page }) => {
+	await page.keyboard.press(`${modifier}+k`);
+
+	const palette = page.getByRole("dialog", { name: "Ability palette" });
+	await expect(palette).toBeVisible();
+	await expect(palette.getByRole("option").first()).toBeVisible();
+
+	await page.keyboard.press("Escape");
+	await expect(palette).toBeHidden();
+});
+
+test("Cmd+J still opens it", async ({ page }) => {
+	await page.keyboard.press(`${modifier}+j`);
+
+	await expect(
+		page.getByRole("dialog", { name: "Ability palette" }),
+	).toBeVisible();
+});
+
+test("it still looks like core's palette", async ({ page }) => {
+	// The admin concatenates styles, so no per-handle link exists.
+	const bundled = await page.evaluate(() =>
+		[...document.querySelectorAll("link[rel=stylesheet]")].some((link) =>
+			decodeURIComponent((link as HTMLLinkElement).href).includes(
+				"wp-commands",
+			),
+		),
+	);
+	// Nothing else enqueues it now, so our own style dependency put it there.
+	expect(bundled).toBe(true);
+
+	await page.keyboard.press(`${modifier}+j`);
+	const input = page
+		.getByRole("dialog", { name: "Ability palette" })
+		.getByRole("combobox");
+	await expect(input).toBeVisible();
+
+	// Unstyled, the input would sit at the browser default of about 13px.
+	const fontSize = await input.evaluate((el) => getComputedStyle(el).fontSize);
+	expect(Number.parseFloat(fontSize)).toBeGreaterThan(14);
+});


### PR DESCRIPTION
Some sites turn WordPress' own command palette off. This plugin has always claimed to keep working when they do — falling back to Cmd+K, since nothing else is using it there — but nothing had ever actually tried it, so it was a claim rather than a fact.

This adds a test suite that runs on a site with core's palette removed, and checks the palette still opens on Cmd+K, still opens on Cmd+J, and still looks the way it does everywhere else rather than dropping to unstyled browser defaults.

- Nothing had to change to make it pass, which is the point of it. The palette was never built on core's — it borrows core's stylesheet so it matches the rest of the admin, and that arrives on its own whether or not core's palette is on the page.
- Tests only. No change to the plugin itself.

_PR description generated by Claude._
