### PR TITLE
Render a union schema as a choice of arm plus that arm's fields

### DIFF
--- a/src/lib/abilities.ts
+++ b/src/lib/abilities.ts
@@ -8,6 +8,8 @@ export type JsonSchema = {
 	// Core keeps a draft-04 tuple as an array of schemas, one per slot.
 	items?: JsonSchema | JsonSchema[];
 	enum?: unknown[];
+	// A discriminated union of object branches; anything else stays refused.
+	oneOf?: JsonSchema[];
 	required?: string[];
 	default?: unknown;
 	additionalProperties?: boolean | JsonSchema;

--- a/src/lib/schema-form.ts
+++ b/src/lib/schema-form.ts
@@ -67,11 +67,29 @@ export type Field = Control & {
 	defaultValue?: unknown;
 };
 
+// One arm of a top-level `oneOf`. A null name is the component's cue to number it.
+export type Branch = {
+	key: string;
+	name: string | null;
+	// What the discriminator holds for this arm, absent when it pins nothing.
+	value?: unknown;
+	form: Form;
+};
+
+export type Union = {
+	discriminator: string | null;
+	// The discriminator humanized, since a property name has no other label.
+	label: string | null;
+	branches: Branch[];
+};
+
 export type Form = {
 	fields: Field[];
 	// A schema no form can show, as opposed to one field that cannot.
 	unsupported: UnsupportedReason | null;
 	defaultValue?: unknown;
+	// Present instead of fields: pick an arm, then fill that arm's own form.
+	union?: Union;
 };
 
 // Stands in for a row index until a row exists to number.
@@ -263,6 +281,189 @@ const toField = (
 	}
 };
 
+const pinned = (schema: unknown): unknown => {
+	if (!schema || typeof schema !== "object") return undefined;
+	const { enum: values } = schema as JsonSchema;
+
+	return Array.isArray(values) && values.length === 1 ? values[0] : undefined;
+};
+
+// An arm must declare type object, the same bar a nested object property clears.
+const objectBranches = (value: unknown): JsonSchema[] | null => {
+	if (!Array.isArray(value) || value.length < 2) return null;
+
+	const branches = value.filter(
+		(branch): branch is JsonSchema =>
+			!!branch &&
+			typeof branch === "object" &&
+			(branch as JsonSchema).type === "object" &&
+			!!(branch as JsonSchema).properties,
+	);
+
+	return branches.length === value.length ? branches : null;
+};
+
+// Pinned to one value in at least two arms, and never the same value twice.
+const findDiscriminator = (branches: JsonSchema[]): string | null => {
+	const pinnedBy = new Map<string, unknown[]>();
+
+	for (const branch of branches) {
+		for (const [name, child] of Object.entries(branch.properties ?? {})) {
+			const value = pinned(child);
+			if (value === undefined) continue;
+
+			pinnedBy.set(name, [...(pinnedBy.get(name) ?? []), value]);
+		}
+	}
+
+	let found: string | null = null;
+	let best = 1;
+	for (const [name, values] of pinnedBy) {
+		const distinct = new Set(values.map((value) => JSON.stringify(value)));
+		if (values.length <= best || distinct.size !== values.length) continue;
+
+		found = name;
+		best = values.length;
+	}
+
+	return found;
+};
+
+// The Select already says which arm this is, so the arm does not ask again.
+const withoutDiscriminator = (
+	branch: JsonSchema,
+	discriminator: string | null,
+): JsonSchema => {
+	if (!discriminator || !branch.properties?.[discriminator]) return branch;
+
+	const properties = { ...branch.properties };
+	delete properties[discriminator];
+
+	return {
+		...branch,
+		properties,
+		required: Array.isArray(branch.required)
+			? branch.required.filter((name) => name !== discriminator)
+			: branch.required,
+	};
+};
+
+const unionForm = (branches: JsonSchema[], fallbackLabel: string): Form => {
+	const discriminator = findDiscriminator(branches);
+
+	return {
+		fields: [],
+		unsupported: null,
+		union: {
+			discriminator,
+			label: discriminator ? humanize(discriminator) : null,
+			branches: branches.map((branch, index) => {
+				const value = discriminator
+					? pinned(branch.properties?.[discriminator])
+					: undefined;
+				const name =
+					typeof branch.title === "string"
+						? branch.title
+						: typeof value === "string"
+							? value
+							: null;
+
+				return {
+					key: String(index),
+					name,
+					value,
+					form: toForm(
+						withoutDiscriminator(branch, discriminator),
+						fallbackLabel,
+					),
+				};
+			}),
+		},
+	};
+};
+
+// The arm being filled in, or the whole form when there is no union.
+export const activeForm = (form: Form, key: string | null): Form => {
+	if (!form.union) return form;
+
+	const branch =
+		form.union.branches.find((candidate) => candidate.key === key) ??
+		form.union.branches[0];
+
+	return branch.form;
+};
+
+export const branchFor = (form: Form, key: string | null): Branch | null => {
+	if (!form.union) return null;
+
+	return (
+		form.union.branches.find((candidate) => candidate.key === key) ??
+		form.union.branches[0]
+	);
+};
+
+// A value survives a switch only if its field and its control both do.
+const controlsByKey = (form: Form) => {
+	const controls = new Map<string, Field["control"]>();
+	const walk = (field: Field) => {
+		controls.set(field.key, field.control);
+		if (field.control === "group") field.fields.forEach(walk);
+	};
+	form.fields.forEach(walk);
+
+	return controls;
+};
+
+const pathsByKey = (form: Form) => {
+	const paths = new Map<string, string[]>();
+	const walk = (field: Field) => {
+		paths.set(field.key, field.path);
+		if (field.control === "group") field.fields.forEach(walk);
+	};
+	form.fields.forEach(walk);
+
+	return paths;
+};
+
+// No field carries the Select's value, and the server checks the arm against it.
+export const withDiscriminator = (
+	form: Form,
+	key: string | null,
+	input: unknown,
+): unknown => {
+	const branch = branchFor(form, key);
+	const discriminator = form.union?.discriminator;
+
+	return discriminator && branch?.value !== undefined
+		? writeAt(input, [discriminator], branch.value)
+		: input;
+};
+
+export const startingInput = (form: Form, key: string | null): unknown =>
+	withDiscriminator(form, key, initialInput(activeForm(form, key)));
+
+export const switchBranch = (
+	form: Form,
+	from: string | null,
+	to: string | null,
+	input: unknown,
+): unknown => {
+	const was = controlsByKey(activeForm(form, from));
+	const entering = activeForm(form, to);
+	const paths = pathsByKey(entering);
+
+	let next = startingInput(form, to);
+	for (const [key, control] of controlsByKey(entering)) {
+		if (was.get(key) !== control) continue;
+
+		const path = paths.get(key);
+		const value = path && readAt(input, path);
+		if (path && value !== undefined) next = writeAt(next, path, value);
+	}
+
+	return next;
+};
+
 export const toForm = (
 	schema: JsonSchema | undefined,
 	fallbackLabel = "",
@@ -271,6 +472,10 @@ export const toForm = (
 	if (!schema || !Object.keys(schema).length) {
 		return { fields: [], unsupported: null };
 	}
+
+	// Only at the top level; alternation inside a property stays refused.
+	const branches = objectBranches(schema.oneOf);
+	if (branches) return unionForm(branches, fallbackLabel);
 
 	const resolved = resolveType(schema);
 	if ("reason" in resolved) return { fields: [], unsupported: resolved.reason };

--- a/src/palette/ability-form.tsx
+++ b/src/palette/ability-form.tsx
@@ -27,16 +27,19 @@ import {
 	runRequest,
 } from "../lib/ability-run";
 import {
+	activeForm,
 	emptyValue,
 	type Field,
 	type FieldError,
 	fieldErrors,
-	initialInput,
 	itemField,
 	type Option,
 	readAt,
+	startingInput,
+	switchBranch,
 	toForm,
 	type UnsupportedReason,
+	withDiscriminator,
 	writeAt,
 } from "../lib/schema-form";
 
@@ -415,16 +418,23 @@ export const AbilityForm = ({
 		() => toForm(ability.input_schema, ability.label),
 		[ability],
 	);
-	const [input, setInput] = useState<unknown>(() => initialInput(form));
+	const [branch, setBranch] = useState<string | null>(
+		() => form.union?.branches[0].key ?? null,
+	);
+	// The arm being filled in, which for anything but a union is the form itself.
+	const active = useMemo(() => activeForm(form, branch), [form, branch]);
+	const [input, setInput] = useState<unknown>(() =>
+		startingInput(form, branch),
+	);
 	const [run, setRun] = useState<RunState>(IDLE);
-	const errors = fieldErrors(form, input);
+	const errors = fieldErrors(active, input);
 	const container = useRef<HTMLFormElement>(null);
 	const confirmRun = useRef<HTMLButtonElement>(null);
 	const outcome = useRef<HTMLDivElement>(null);
 
 	const confirm = confirmKind(ability);
-	const runnable = !form.unsupported && !!runHref(ability);
-	const blocked = !!Object.keys(errors).length || hasUnfillable(form);
+	const runnable = !active.unsupported && !!runHref(ability);
+	const blocked = !!Object.keys(errors).length || hasUnfillable(active);
 
 	useEffect(() => {
 		container.current?.querySelector<HTMLElement>("input, select")?.focus();
@@ -449,7 +459,11 @@ export const AbilityForm = ({
 	}, []);
 
 	const send = useCallback(async () => {
-		const request = runRequest(ability, coerceInput(form, input));
+		// coerceInput builds from the arm's fields, which the discriminator is not one of.
+		const request = runRequest(
+			ability,
+			withDiscriminator(form, branch, coerceInput(active, input)),
+		);
 		if (!request) return;
 
 		setRun({ status: "running" });
@@ -466,7 +480,7 @@ export const AbilityForm = ({
 					__("The ability could not be run.", "command-palette-tools"),
 			});
 		}
-	}, [ability, form, input]);
+	}, [ability, active, branch, form, input]);
 
 	const submit = (event: React.FormEvent) => {
 		event.preventDefault();
@@ -494,12 +508,36 @@ export const AbilityForm = ({
 			{ability.description && (
 				<p className="wpcp-tools-palette__help">{ability.description}</p>
 			)}
-			{form.unsupported ? (
+			{form.union && (
+				<SelectControl
+					__nextHasNoMarginBottom
+					label={form.union.label ?? __("Kind", "command-palette-tools")}
+					value={branch ?? form.union.branches[0].key}
+					options={form.union.branches.map((option, index) => ({
+						label:
+							option.name ??
+							sprintf(
+								/* translators: %d: position of an unnamed choice in the list. */
+								__("Option %d", "command-palette-tools"),
+								index + 1,
+							),
+						value: option.key,
+					}))}
+					onChange={(key) => {
+						setInput(switchBranch(form, branch, key, input));
+						setBranch(key);
+						setRun((current) =>
+							current.status === "running" ? current : IDLE,
+						);
+					}}
+				/>
+			)}
+			{active.unsupported ? (
 				<Notice status="warning" isDismissible={false}>
-					{reasonText(form.unsupported)}
+					{reasonText(active.unsupported)}
 				</Notice>
 			) : (
-				form.fields.map((field) => (
+				active.fields.map((field) => (
 					<FieldRow
 						key={field.key}
 						field={field}
@@ -509,7 +547,7 @@ export const AbilityForm = ({
 					/>
 				))
 			)}
-			{!form.unsupported && !form.fields.length && (
+			{!active.unsupported && !form.union && !active.fields.length && (
 				<p className="wpcp-tools-palette__help">
 					{__("This ability takes no input.", "command-palette-tools")}
 				</p>

--- a/tests/run/fixture-abilities.php
+++ b/tests/run/fixture-abilities.php
@@ -52,6 +52,45 @@ add_action('wp_abilities_api_init', function () {
 		],
 	]);
 
+	// A discriminated union, which is how WooCommerce writes its product schemas.
+	wp_register_ability('wpcp-test/book-a-slot', [
+		'label' => 'Book Test Slot',
+		'description' => 'Takes one of two shapes depending on what is being booked.',
+		'category' => 'site',
+		'input_schema' => [
+			'type' => 'object',
+			'oneOf' => [
+				[
+					'type' => 'object',
+					'properties' => [
+						'kind' => ['type' => 'string', 'enum' => ['room']],
+						'name' => ['type' => 'string', 'description' => 'Who it is for.'],
+						'floor' => ['type' => 'integer'],
+					],
+					'required' => ['kind', 'name'],
+					'additionalProperties' => false,
+				],
+				[
+					'type' => 'object',
+					'properties' => [
+						'kind' => ['type' => 'string', 'enum' => ['desk']],
+						'name' => ['type' => 'string', 'description' => 'Who it is for.'],
+						'standing' => ['type' => 'boolean'],
+					],
+					'required' => ['kind', 'name'],
+					'additionalProperties' => false,
+				],
+			],
+		],
+		'output_schema' => ['type' => 'object'],
+		'execute_callback' => fn($input) => ['booked' => $input],
+		'permission_callback' => fn() => current_user_can('manage_options'),
+		'meta' => [
+			'public' => true,
+			'annotations' => ['readonly' => false, 'destructive' => false, 'idempotent' => false],
+		],
+	]);
+
 	// No input schema at all is how an ability says it takes none.
 	wp_register_ability('wpcp-test/always-fails', [
 		'label' => 'Fail Test Run',

--- a/tests/run/run.spec.ts
+++ b/tests/run/run.spec.ts
@@ -84,3 +84,41 @@ test("the palette shows the reason the site gave for refusing", async ({
 	).toBeVisible();
 	await expect(palette.getByRole("heading", { name: "Result" })).toBeHidden();
 });
+
+test("a union schema picks an arm and sends what that arm asked for", async ({
+	page,
+}) => {
+	const palette = page.getByRole("dialog", { name: "Ability palette" });
+	await palette.getByRole("option", { name: /Book Test Slot/ }).click();
+
+	// The arms pin `kind`, so it becomes the picker rather than a field.
+	const kind = palette.getByRole("combobox", { name: "Kind" });
+	await expect(kind).toBeVisible();
+	await expect(kind).toHaveValue("0");
+	await expect(
+		palette.getByRole("spinbutton", { name: /Floor/ }),
+	).toBeVisible();
+	await expect(
+		palette.getByRole("checkbox", { name: /Standing/ }),
+	).toBeHidden();
+
+	await palette.getByRole("textbox", { name: /Name/ }).fill("Ada");
+	await kind.selectOption("1");
+
+	// The shared field keeps what was typed; the first arm's own is gone.
+	await expect(palette.getByRole("textbox", { name: /Name/ })).toHaveValue(
+		"Ada",
+	);
+	await expect(
+		palette.getByRole("checkbox", { name: /Standing/ }),
+	).toBeVisible();
+	await expect(palette.getByRole("spinbutton", { name: /Floor/ })).toBeHidden();
+
+	await palette.getByRole("button", { name: "Run", exact: true }).click();
+	await palette.getByRole("button", { name: "Yes, run it" }).click();
+
+	await expect(palette.getByRole("heading", { name: "Result" })).toBeVisible();
+	// The picker's own value has to travel, since the server validates the arm.
+	await expect(palette.getByText('"kind": "desk"')).toBeVisible();
+	await expect(palette.getByText('"name": "Ada"')).toBeVisible();
+});

--- a/tests/unit/fixtures/woocommerce-schemas.json
+++ b/tests/unit/fixtures/woocommerce-schemas.json
@@ -1,0 +1,542 @@
+{
+	"product-create": {
+		"type": "object",
+		"oneOf": [
+			{
+				"type": "object",
+				"properties": {
+					"product_type_alias": {
+						"type": "string",
+						"description": "Supported agent-facing product type alias. physical maps to a simple shippable, non-downloadable product; virtual maps to a simple non-shipping, non-downloadable product; digital maps to a simple virtual/downloadable product; affiliate maps to the external product type; grouped maps to grouped.",
+						"enum": ["physical"],
+						"default": "physical"
+					},
+					"name": {
+						"type": "string"
+					},
+					"sku": {
+						"type": "string"
+					},
+					"regular_price": {
+						"type": "string",
+						"description": "Decimal price as a string, without a currency symbol or thousand separators.",
+						"pattern": "^(?:-?(?:[0-9]+(?:[\\.][0-9]+)?|[\\.][0-9]+)|)$"
+					},
+					"sale_price": {
+						"type": "string",
+						"description": "Decimal price as a string, without a currency symbol or thousand separators.",
+						"pattern": "^(?:-?(?:[0-9]+(?:[\\.][0-9]+)?|[\\.][0-9]+)|)$"
+					},
+					"description": {
+						"type": "string",
+						"description": "Product description content. Safe HTML is allowed."
+					},
+					"short_description": {
+						"type": "string",
+						"description": "Short product description content. Safe HTML is allowed."
+					},
+					"status": {
+						"type": "string",
+						"enum": ["draft", "pending", "private", "publish", "future"]
+					},
+					"manage_stock": {
+						"type": "boolean"
+					},
+					"stock_quantity": {
+						"type": "integer",
+						"description": "Available stock quantity when product-level stock management is used."
+					},
+					"stock_status": {
+						"type": "string",
+						"enum": ["instock", "outofstock", "onbackorder"]
+					}
+				},
+				"required": ["name"],
+				"additionalProperties": false
+			},
+			{
+				"type": "object",
+				"properties": {
+					"product_type_alias": {
+						"type": "string",
+						"description": "Supported agent-facing product type alias. physical maps to a simple shippable, non-downloadable product; virtual maps to a simple non-shipping, non-downloadable product; digital maps to a simple virtual/downloadable product; affiliate maps to the external product type; grouped maps to grouped.",
+						"enum": ["virtual"]
+					},
+					"name": {
+						"type": "string"
+					},
+					"sku": {
+						"type": "string"
+					},
+					"regular_price": {
+						"type": "string",
+						"description": "Decimal price as a string, without a currency symbol or thousand separators.",
+						"pattern": "^(?:-?(?:[0-9]+(?:[\\.][0-9]+)?|[\\.][0-9]+)|)$"
+					},
+					"sale_price": {
+						"type": "string",
+						"description": "Decimal price as a string, without a currency symbol or thousand separators.",
+						"pattern": "^(?:-?(?:[0-9]+(?:[\\.][0-9]+)?|[\\.][0-9]+)|)$"
+					},
+					"description": {
+						"type": "string",
+						"description": "Product description content. Safe HTML is allowed."
+					},
+					"short_description": {
+						"type": "string",
+						"description": "Short product description content. Safe HTML is allowed."
+					},
+					"status": {
+						"type": "string",
+						"enum": ["draft", "pending", "private", "publish", "future"]
+					},
+					"manage_stock": {
+						"type": "boolean"
+					},
+					"stock_quantity": {
+						"type": "integer",
+						"description": "Available stock quantity when product-level stock management is used."
+					},
+					"stock_status": {
+						"type": "string",
+						"enum": ["instock", "outofstock", "onbackorder"]
+					}
+				},
+				"required": ["name", "product_type_alias"],
+				"additionalProperties": false
+			},
+			{
+				"type": "object",
+				"properties": {
+					"product_type_alias": {
+						"type": "string",
+						"description": "Supported agent-facing product type alias. physical maps to a simple shippable, non-downloadable product; virtual maps to a simple non-shipping, non-downloadable product; digital maps to a simple virtual/downloadable product; affiliate maps to the external product type; grouped maps to grouped.",
+						"enum": ["digital"]
+					},
+					"name": {
+						"type": "string"
+					},
+					"sku": {
+						"type": "string"
+					},
+					"regular_price": {
+						"type": "string",
+						"description": "Decimal price as a string, without a currency symbol or thousand separators.",
+						"pattern": "^(?:-?(?:[0-9]+(?:[\\.][0-9]+)?|[\\.][0-9]+)|)$"
+					},
+					"sale_price": {
+						"type": "string",
+						"description": "Decimal price as a string, without a currency symbol or thousand separators.",
+						"pattern": "^(?:-?(?:[0-9]+(?:[\\.][0-9]+)?|[\\.][0-9]+)|)$"
+					},
+					"description": {
+						"type": "string",
+						"description": "Product description content. Safe HTML is allowed."
+					},
+					"short_description": {
+						"type": "string",
+						"description": "Short product description content. Safe HTML is allowed."
+					},
+					"status": {
+						"type": "string",
+						"enum": ["draft", "pending", "private", "publish", "future"]
+					},
+					"manage_stock": {
+						"type": "boolean"
+					},
+					"stock_quantity": {
+						"type": "integer",
+						"description": "Available stock quantity when product-level stock management is used."
+					},
+					"stock_status": {
+						"type": "string",
+						"enum": ["instock", "outofstock", "onbackorder"]
+					}
+				},
+				"required": ["name", "product_type_alias"],
+				"additionalProperties": false
+			},
+			{
+				"type": "object",
+				"properties": {
+					"product_type_alias": {
+						"type": "string",
+						"description": "Supported agent-facing product type alias. physical maps to a simple shippable, non-downloadable product; virtual maps to a simple non-shipping, non-downloadable product; digital maps to a simple virtual/downloadable product; affiliate maps to the external product type; grouped maps to grouped.",
+						"enum": ["affiliate"]
+					},
+					"name": {
+						"type": "string"
+					},
+					"sku": {
+						"type": "string"
+					},
+					"regular_price": {
+						"type": "string",
+						"description": "Decimal price as a string, without a currency symbol or thousand separators.",
+						"pattern": "^(?:-?(?:[0-9]+(?:[\\.][0-9]+)?|[\\.][0-9]+)|)$"
+					},
+					"sale_price": {
+						"type": "string",
+						"description": "Decimal price as a string, without a currency symbol or thousand separators.",
+						"pattern": "^(?:-?(?:[0-9]+(?:[\\.][0-9]+)?|[\\.][0-9]+)|)$"
+					},
+					"description": {
+						"type": "string",
+						"description": "Product description content. Safe HTML is allowed."
+					},
+					"short_description": {
+						"type": "string",
+						"description": "Short product description content. Safe HTML is allowed."
+					},
+					"status": {
+						"type": "string",
+						"enum": ["draft", "pending", "private", "publish", "future"]
+					},
+					"external_url": {
+						"type": "string",
+						"description": "External destination URL for affiliate products.",
+						"format": "uri"
+					},
+					"button_text": {
+						"type": "string",
+						"description": "Button text for affiliate products."
+					}
+				},
+				"required": ["name", "product_type_alias"],
+				"additionalProperties": false
+			},
+			{
+				"type": "object",
+				"properties": {
+					"product_type_alias": {
+						"type": "string",
+						"description": "Supported agent-facing product type alias. physical maps to a simple shippable, non-downloadable product; virtual maps to a simple non-shipping, non-downloadable product; digital maps to a simple virtual/downloadable product; affiliate maps to the external product type; grouped maps to grouped.",
+						"enum": ["grouped"]
+					},
+					"name": {
+						"type": "string"
+					},
+					"sku": {
+						"type": "string"
+					},
+					"description": {
+						"type": "string",
+						"description": "Product description content. Safe HTML is allowed."
+					},
+					"short_description": {
+						"type": "string",
+						"description": "Short product description content. Safe HTML is allowed."
+					},
+					"status": {
+						"type": "string",
+						"enum": ["draft", "pending", "private", "publish", "future"]
+					},
+					"grouped_products": {
+						"type": "array",
+						"description": "Product IDs to include as children of a grouped product.",
+						"items": {
+							"type": "integer",
+							"minimum": 1
+						}
+					}
+				},
+				"required": ["name", "product_type_alias"],
+				"additionalProperties": false
+			}
+		]
+	},
+	"product-update": {
+		"type": "object",
+		"oneOf": [
+			{
+				"type": "object",
+				"properties": {
+					"id": {
+						"type": "integer",
+						"minimum": 1
+					},
+					"name": {
+						"type": "string"
+					},
+					"sku": {
+						"type": "string"
+					},
+					"description": {
+						"type": "string",
+						"description": "Product description content. Safe HTML is allowed."
+					},
+					"short_description": {
+						"type": "string",
+						"description": "Short product description content. Safe HTML is allowed."
+					},
+					"status": {
+						"type": "string",
+						"enum": ["draft", "pending", "private", "publish", "future"]
+					}
+				},
+				"required": ["id"],
+				"additionalProperties": false
+			},
+			{
+				"type": "object",
+				"properties": {
+					"id": {
+						"type": "integer",
+						"minimum": 1
+					},
+					"product_type_alias": {
+						"type": "string",
+						"description": "Supported agent-facing product type alias. physical maps to a simple shippable, non-downloadable product; virtual maps to a simple non-shipping, non-downloadable product; digital maps to a simple virtual/downloadable product; affiliate maps to the external product type; grouped maps to grouped.",
+						"enum": ["physical"]
+					},
+					"name": {
+						"type": "string"
+					},
+					"sku": {
+						"type": "string"
+					},
+					"regular_price": {
+						"type": "string",
+						"description": "Decimal price as a string, without a currency symbol or thousand separators.",
+						"pattern": "^(?:-?(?:[0-9]+(?:[\\.][0-9]+)?|[\\.][0-9]+)|)$"
+					},
+					"sale_price": {
+						"type": "string",
+						"description": "Decimal price as a string, without a currency symbol or thousand separators.",
+						"pattern": "^(?:-?(?:[0-9]+(?:[\\.][0-9]+)?|[\\.][0-9]+)|)$"
+					},
+					"description": {
+						"type": "string",
+						"description": "Product description content. Safe HTML is allowed."
+					},
+					"short_description": {
+						"type": "string",
+						"description": "Short product description content. Safe HTML is allowed."
+					},
+					"status": {
+						"type": "string",
+						"enum": ["draft", "pending", "private", "publish", "future"]
+					},
+					"manage_stock": {
+						"type": "boolean"
+					},
+					"stock_quantity": {
+						"type": "integer",
+						"description": "Available stock quantity when product-level stock management is used."
+					},
+					"stock_status": {
+						"type": "string",
+						"enum": ["instock", "outofstock", "onbackorder"]
+					}
+				},
+				"required": ["id", "product_type_alias"],
+				"additionalProperties": false
+			},
+			{
+				"type": "object",
+				"properties": {
+					"id": {
+						"type": "integer",
+						"minimum": 1
+					},
+					"product_type_alias": {
+						"type": "string",
+						"description": "Supported agent-facing product type alias. physical maps to a simple shippable, non-downloadable product; virtual maps to a simple non-shipping, non-downloadable product; digital maps to a simple virtual/downloadable product; affiliate maps to the external product type; grouped maps to grouped.",
+						"enum": ["virtual"]
+					},
+					"name": {
+						"type": "string"
+					},
+					"sku": {
+						"type": "string"
+					},
+					"regular_price": {
+						"type": "string",
+						"description": "Decimal price as a string, without a currency symbol or thousand separators.",
+						"pattern": "^(?:-?(?:[0-9]+(?:[\\.][0-9]+)?|[\\.][0-9]+)|)$"
+					},
+					"sale_price": {
+						"type": "string",
+						"description": "Decimal price as a string, without a currency symbol or thousand separators.",
+						"pattern": "^(?:-?(?:[0-9]+(?:[\\.][0-9]+)?|[\\.][0-9]+)|)$"
+					},
+					"description": {
+						"type": "string",
+						"description": "Product description content. Safe HTML is allowed."
+					},
+					"short_description": {
+						"type": "string",
+						"description": "Short product description content. Safe HTML is allowed."
+					},
+					"status": {
+						"type": "string",
+						"enum": ["draft", "pending", "private", "publish", "future"]
+					},
+					"manage_stock": {
+						"type": "boolean"
+					},
+					"stock_quantity": {
+						"type": "integer",
+						"description": "Available stock quantity when product-level stock management is used."
+					},
+					"stock_status": {
+						"type": "string",
+						"enum": ["instock", "outofstock", "onbackorder"]
+					}
+				},
+				"required": ["id", "product_type_alias"],
+				"additionalProperties": false
+			},
+			{
+				"type": "object",
+				"properties": {
+					"id": {
+						"type": "integer",
+						"minimum": 1
+					},
+					"product_type_alias": {
+						"type": "string",
+						"description": "Supported agent-facing product type alias. physical maps to a simple shippable, non-downloadable product; virtual maps to a simple non-shipping, non-downloadable product; digital maps to a simple virtual/downloadable product; affiliate maps to the external product type; grouped maps to grouped.",
+						"enum": ["digital"]
+					},
+					"name": {
+						"type": "string"
+					},
+					"sku": {
+						"type": "string"
+					},
+					"regular_price": {
+						"type": "string",
+						"description": "Decimal price as a string, without a currency symbol or thousand separators.",
+						"pattern": "^(?:-?(?:[0-9]+(?:[\\.][0-9]+)?|[\\.][0-9]+)|)$"
+					},
+					"sale_price": {
+						"type": "string",
+						"description": "Decimal price as a string, without a currency symbol or thousand separators.",
+						"pattern": "^(?:-?(?:[0-9]+(?:[\\.][0-9]+)?|[\\.][0-9]+)|)$"
+					},
+					"description": {
+						"type": "string",
+						"description": "Product description content. Safe HTML is allowed."
+					},
+					"short_description": {
+						"type": "string",
+						"description": "Short product description content. Safe HTML is allowed."
+					},
+					"status": {
+						"type": "string",
+						"enum": ["draft", "pending", "private", "publish", "future"]
+					},
+					"manage_stock": {
+						"type": "boolean"
+					},
+					"stock_quantity": {
+						"type": "integer",
+						"description": "Available stock quantity when product-level stock management is used."
+					},
+					"stock_status": {
+						"type": "string",
+						"enum": ["instock", "outofstock", "onbackorder"]
+					}
+				},
+				"required": ["id", "product_type_alias"],
+				"additionalProperties": false
+			},
+			{
+				"type": "object",
+				"properties": {
+					"id": {
+						"type": "integer",
+						"minimum": 1
+					},
+					"product_type_alias": {
+						"type": "string",
+						"description": "Supported agent-facing product type alias. physical maps to a simple shippable, non-downloadable product; virtual maps to a simple non-shipping, non-downloadable product; digital maps to a simple virtual/downloadable product; affiliate maps to the external product type; grouped maps to grouped.",
+						"enum": ["affiliate"]
+					},
+					"name": {
+						"type": "string"
+					},
+					"sku": {
+						"type": "string"
+					},
+					"regular_price": {
+						"type": "string",
+						"description": "Decimal price as a string, without a currency symbol or thousand separators.",
+						"pattern": "^(?:-?(?:[0-9]+(?:[\\.][0-9]+)?|[\\.][0-9]+)|)$"
+					},
+					"sale_price": {
+						"type": "string",
+						"description": "Decimal price as a string, without a currency symbol or thousand separators.",
+						"pattern": "^(?:-?(?:[0-9]+(?:[\\.][0-9]+)?|[\\.][0-9]+)|)$"
+					},
+					"description": {
+						"type": "string",
+						"description": "Product description content. Safe HTML is allowed."
+					},
+					"short_description": {
+						"type": "string",
+						"description": "Short product description content. Safe HTML is allowed."
+					},
+					"status": {
+						"type": "string",
+						"enum": ["draft", "pending", "private", "publish", "future"]
+					},
+					"external_url": {
+						"type": "string",
+						"description": "External destination URL for affiliate products.",
+						"format": "uri"
+					},
+					"button_text": {
+						"type": "string",
+						"description": "Button text for affiliate products."
+					}
+				},
+				"required": ["id", "product_type_alias"],
+				"additionalProperties": false
+			},
+			{
+				"type": "object",
+				"properties": {
+					"id": {
+						"type": "integer",
+						"minimum": 1
+					},
+					"product_type_alias": {
+						"type": "string",
+						"description": "Supported agent-facing product type alias. physical maps to a simple shippable, non-downloadable product; virtual maps to a simple non-shipping, non-downloadable product; digital maps to a simple virtual/downloadable product; affiliate maps to the external product type; grouped maps to grouped.",
+						"enum": ["grouped"]
+					},
+					"name": {
+						"type": "string"
+					},
+					"sku": {
+						"type": "string"
+					},
+					"description": {
+						"type": "string",
+						"description": "Product description content. Safe HTML is allowed."
+					},
+					"short_description": {
+						"type": "string",
+						"description": "Short product description content. Safe HTML is allowed."
+					},
+					"status": {
+						"type": "string",
+						"enum": ["draft", "pending", "private", "publish", "future"]
+					},
+					"grouped_products": {
+						"type": "array",
+						"description": "Product IDs to include as children of a grouped product.",
+						"items": {
+							"type": "integer",
+							"minimum": 1
+						}
+					}
+				},
+				"required": ["id", "product_type_alias"],
+				"additionalProperties": false
+			}
+		]
+	}
+}

--- a/tests/unit/schema-form.test.ts
+++ b/tests/unit/schema-form.test.ts
@@ -1,15 +1,28 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import { describe, it } from "node:test";
 import type { JsonSchema } from "../../src/lib/abilities.ts";
 import {
+	activeForm,
+	branchFor,
 	type Field,
 	fieldErrors,
 	initialInput,
 	itemField,
 	readAt,
+	switchBranch,
 	toForm,
+	withDiscriminator,
 	writeAt,
 } from "../../src/lib/schema-form.ts";
+
+// WooCommerce 11.0.1's own, read off the REST listing rather than rewritten.
+const WOO: Record<string, JsonSchema> = JSON.parse(
+	readFileSync(
+		new URL("./fixtures/woocommerce-schemas.json", import.meta.url),
+		"utf8",
+	),
+);
 
 // What all three of core's abilities ship on WP 7.1.
 const CORE_SCHEMA: JsonSchema = {
@@ -400,5 +413,284 @@ describe("fieldErrors", () => {
 		});
 
 		assert.deepEqual(fieldErrors(unshowable, {}), {});
+	});
+});
+
+const UNION: JsonSchema = {
+	type: "object",
+	oneOf: [
+		{
+			type: "object",
+			properties: {
+				kind: { type: "string", enum: ["letter"] },
+				subject: { type: "string" },
+				pages: { type: "integer" },
+			},
+			required: ["kind", "subject"],
+		},
+		{
+			type: "object",
+			properties: {
+				kind: { type: "string", enum: ["parcel"] },
+				subject: { type: "string" },
+				weight: { type: "number" },
+			},
+			required: ["kind", "weight"],
+		},
+	],
+};
+
+describe("toForm on a union", () => {
+	it("finds the property the arms disagree on", () => {
+		const form = toForm(UNION);
+
+		assert.equal(form.unsupported, null);
+		assert.equal(form.union?.discriminator, "kind");
+		assert.deepEqual(
+			form.union?.branches.map(({ name }) => name),
+			["letter", "parcel"],
+		);
+	});
+
+	// Picking the arm already says which it is, so the arm must not ask again.
+	it("leaves the discriminator out of the arm's own fields", () => {
+		const form = toForm(UNION);
+		const letter = activeForm(form, "0");
+
+		assert.deepEqual(
+			letter.fields.map(({ key }) => key),
+			["subject", "pages"],
+		);
+		assert.equal(
+			letter.fields.find(({ key }) => key === "subject")?.required,
+			true,
+		);
+	});
+
+	it("puts no fields at the top level", () => {
+		assert.deepEqual(toForm(UNION).fields, []);
+	});
+
+	it("falls back to the first arm for a key that is not there", () => {
+		const form = toForm(UNION);
+
+		assert.equal(branchFor(form, null)?.name, "letter");
+		assert.equal(branchFor(form, "nope")?.name, "letter");
+	});
+
+	it("prefers a title the schema supplies over the pinned value", () => {
+		const titled: JsonSchema = {
+			oneOf: [
+				{
+					type: "object",
+					title: "A letter",
+					properties: { kind: { type: "string", enum: ["letter"] } },
+				},
+				{
+					type: "object",
+					properties: { kind: { type: "string", enum: ["parcel"] } },
+				},
+			],
+		};
+
+		assert.deepEqual(
+			toForm(titled).union?.branches.map(({ name }) => name),
+			["A letter", "parcel"],
+		);
+	});
+
+	it("names nothing when no property is pinned twice", () => {
+		const loose: JsonSchema = {
+			oneOf: [
+				{ type: "object", properties: { a: { type: "string" } } },
+				{ type: "object", properties: { b: { type: "string" } } },
+			],
+		};
+		const form = toForm(loose);
+
+		assert.equal(form.union?.discriminator, null);
+		assert.deepEqual(
+			form.union?.branches.map(({ name }) => name),
+			[null, null],
+		);
+	});
+
+	it("still refuses alternation it cannot render", () => {
+		assert.equal(
+			toForm({ anyOf: [{ type: "string" }] }).unsupported,
+			"alternatives",
+		);
+		assert.equal(
+			toForm({ allOf: [{ type: "object" }] }).unsupported,
+			"alternatives",
+		);
+		// One arm is not a choice, and an arm that declares no object is not one.
+		assert.equal(
+			toForm({ oneOf: [{ type: "object", properties: {} }] }).unsupported,
+			"alternatives",
+		);
+		assert.equal(
+			toForm({
+				oneOf: [{ properties: { a: {} } }, { properties: { b: {} } }],
+			}).unsupported,
+			"alternatives",
+		);
+		assert.equal(
+			toForm({ oneOf: [{ type: "string" }, { type: "number" }] }).unsupported,
+			"alternatives",
+		);
+	});
+
+	it("refuses alternation inside an arm rather than at the top", () => {
+		const nested: JsonSchema = {
+			oneOf: [
+				{
+					type: "object",
+					properties: {
+						kind: { type: "string", enum: ["one"] },
+						odd: { oneOf: [{ type: "string" }] },
+					},
+				},
+				{
+					type: "object",
+					properties: { kind: { type: "string", enum: ["two"] } },
+				},
+			],
+		};
+		const form = toForm(nested);
+
+		assert.equal(form.unsupported, null);
+		const odd = activeForm(form, "0").fields.find(({ key }) => key === "odd");
+		assert.equal(odd?.control, "unsupported");
+		assert.equal(
+			odd?.control === "unsupported" ? odd.reason : null,
+			"alternatives",
+		);
+	});
+});
+
+describe("switchBranch", () => {
+	const form = toForm(UNION);
+
+	it("writes the arm's own value into the discriminator", () => {
+		const input = switchBranch(form, "0", "1", {});
+
+		assert.equal(readAt(input, ["kind"]), "parcel");
+	});
+
+	it("carries a value whose field survives the switch", () => {
+		const input = switchBranch(form, "0", "1", {
+			kind: "letter",
+			subject: "keep me",
+			pages: "3",
+		});
+
+		assert.equal(readAt(input, ["subject"]), "keep me");
+	});
+
+	it("drops a value the arm being entered has no field for", () => {
+		const input = switchBranch(form, "0", "1", {
+			subject: "keep me",
+			pages: "3",
+		});
+
+		assert.equal(readAt(input, ["pages"]), undefined);
+	});
+
+	// Two arms can name the same property as different kinds of value.
+	it("drops a value whose field changed control", () => {
+		const retyped: JsonSchema = {
+			oneOf: [
+				{
+					type: "object",
+					properties: {
+						kind: { type: "string", enum: ["a"] },
+						size: { type: "string" },
+					},
+				},
+				{
+					type: "object",
+					properties: {
+						kind: { type: "string", enum: ["b"] },
+						size: { type: "boolean" },
+					},
+				},
+			],
+		};
+		const input = switchBranch(toForm(retyped), "0", "1", { size: "large" });
+
+		assert.equal(readAt(input, ["size"]), undefined);
+	});
+});
+
+describe("toForm on WooCommerce's own unions", () => {
+	it("renders product-create as five named arms", () => {
+		const form = toForm(WOO["product-create"]);
+
+		assert.equal(form.unsupported, null);
+		assert.equal(form.union?.discriminator, "product_type_alias");
+		assert.deepEqual(
+			form.union?.branches.map(({ name }) => name),
+			["physical", "virtual", "digital", "affiliate", "grouped"],
+		);
+	});
+
+	it("gives every product-create arm a form with fields", () => {
+		for (const branch of toForm(WOO["product-create"]).union?.branches ?? []) {
+			assert.equal(branch.form.unsupported, null, branch.name ?? "?");
+			assert.ok(branch.form.fields.length, branch.name ?? "?");
+			// The Select carries it, so no arm asks for the type again.
+			assert.equal(
+				branch.form.fields.some(({ key }) => key === "product_type_alias"),
+				false,
+			);
+		}
+	});
+
+	it("leaves product-update's unpinned first arm unnamed", () => {
+		const form = toForm(WOO["product-update"]);
+
+		assert.equal(form.union?.discriminator, "product_type_alias");
+		assert.deepEqual(
+			form.union?.branches.map(({ name }) => name),
+			[null, "physical", "virtual", "digital", "affiliate", "grouped"],
+		);
+		// Nothing pinned means nothing to write when that arm is chosen.
+		assert.equal(form.union?.branches[0].value, undefined);
+	});
+
+	it("keeps each arm's own required fields", () => {
+		const form = toForm(WOO["product-create"]);
+		const physical = activeForm(form, "0");
+
+		assert.deepEqual(fieldErrors(physical, initialInput(physical)), {
+			name: { code: "required" },
+		});
+	});
+});
+
+describe("withDiscriminator", () => {
+	const form = toForm(UNION);
+
+	// coerceInput rebuilds from the arm's fields, which this is not one of.
+	it("puts the arm's value back onto a payload built without it", () => {
+		const sent = withDiscriminator(form, "1", { name: "Ada" });
+
+		assert.deepEqual(sent, { name: "Ada", kind: "parcel" });
+	});
+
+	it("leaves a payload alone when the arm pins nothing", () => {
+		const unpinned = toForm(WOO["product-update"]);
+
+		assert.deepEqual(withDiscriminator(unpinned, "0", { id: 7 }), { id: 7 });
+	});
+
+	it("leaves a payload alone when there is no union", () => {
+		const plain = toForm({
+			type: "object",
+			properties: { a: { type: "string" } },
+		});
+
+		assert.deepEqual(withDiscriminator(plain, null, { a: "x" }), { a: "x" });
 	});
 });


### PR DESCRIPTION
Some abilities describe their input as "one of these shapes" rather than as a single set of fields. WooCommerce does it for creating and updating a product: what you fill in depends on whether the product is physical, virtual, digital, an affiliate link or a grouped product. Until now the palette could not draw that, so it showed a note saying so and gave you no form at all — two of WooCommerce's seven abilities arrived unusable.

The palette now asks which one first, then shows the fields for that answer.

- Picking the kind is a dropdown at the top of the form, so you never fill in the same thing twice. Its value is sent along with everything else, since that is what the site checks the rest of the form against.
- Changing your mind keeps what still applies. Type a name, switch from a physical product to a digital one, and the name stays; the fields that only belonged to the old choice go away.
- Each choice keeps its own required fields, so Run stays disabled until the one you picked is actually filled in.
- Shapes that genuinely cannot be drawn are still refused by name rather than half-drawn, and nothing changed about forms that were already working.
- WooCommerce's two real schemas are committed as test fixtures, so this is tested against what a live plugin actually ships rather than against something invented for the test.
- The palette entry grows from 88.3KB to 90.7KB (28.7KB to 29.4KB over the wire).

_PR description generated by Claude._
