### PR TITLE
Put a way into the ability palette inside core's own

### DIFF
--- a/src/palette/palette-menu.tsx
+++ b/src/palette/palette-menu.tsx
@@ -29,6 +29,7 @@ import { fireNotice } from "../lib/wordpress";
 import { AbilityForm } from "./ability-form";
 import { NOTICE_CONTEXT } from "./palette-notices";
 import { recents } from "./recents-store";
+import { useDoorwayCommand } from "./use-doorway-command";
 import { useOpenPalette } from "./use-open-palette";
 
 type Result = {
@@ -112,8 +113,10 @@ export const PaletteMenu = () => {
 
 	const input = useRef<HTMLInputElement>(null);
 
-	const toggle = useCallback(() => setIsOpen((open) => !open), []);
+	const open = useCallback(() => setIsOpen(true), []);
+	const toggle = useCallback(() => setIsOpen((wasOpen) => !wasOpen), []);
 	useOpenPalette(toggle);
+	useDoorwayCommand(open);
 
 	const close = useCallback(() => {
 		setSearch("");

--- a/src/palette/use-doorway-command.ts
+++ b/src/palette/use-doorway-command.ts
@@ -1,0 +1,24 @@
+import { __ } from "@wordpress/i18n";
+import { tool } from "@wordpress/icons";
+import { NAMESPACE } from "../constants";
+import { useCommand } from "../lib/wordpress";
+
+// Module scope: core re-registers a command whose `keywords` array is new.
+const KEYWORDS = [
+	__("abilities", "command-palette-tools"),
+	__("palette", "command-palette-tools"),
+];
+
+export const useDoorwayCommand = (open: () => void) => {
+	useCommand({
+		name: `${NAMESPACE}/run-ability`,
+		label: __("Run an ability…", "command-palette-tools"),
+		keywords: KEYWORDS,
+		icon: tool,
+		// Both are a Modal, so leaving core's open would trap focus inside it.
+		callback: ({ close }) => {
+			close();
+			open();
+		},
+	});
+};

--- a/tests/palette.spec.ts
+++ b/tests/palette.spec.ts
@@ -124,6 +124,41 @@ test("Cmd+K still belongs to core's palette", async ({ admin, page }) => {
 	).toBeHidden();
 });
 
+test("core's palette hands over to this one", async ({ admin, page }) => {
+	await admin.visitAdminPage("plugins.php");
+	await page.keyboard.press(`${modifier}+k`);
+
+	const core = page.getByRole("dialog", { name: "Command palette" });
+	// Core's palette re-filters its own results, so the label has to match.
+	await page.keyboard.type("ability");
+	await core.getByRole("option", { name: /Run an ability/ }).click();
+
+	await expect(core).toBeHidden();
+	const palette = page.getByRole("dialog", { name: "Ability palette" });
+	await expect(palette).toBeVisible();
+
+	// Core's palette returns focus as it unmounts, so typing is the real check.
+	await page.keyboard.type("environment");
+	await expect(palette.getByRole("option")).toHaveText([
+		/Get Environment Info/,
+	]);
+});
+
+test("Cmd+K in the post editor reaches this palette", async ({
+	admin,
+	page,
+}) => {
+	await admin.createNewPost({ title: "Doorway" });
+	await page.keyboard.press(`${modifier}+k`);
+	await page.keyboard.type("ability");
+
+	await page.getByRole("option", { name: /Run an ability/ }).click();
+
+	await expect(
+		page.getByRole("dialog", { name: "Ability palette" }),
+	).toBeVisible();
+});
+
 test("computed results answer the search itself", async ({ admin, page }) => {
 	await admin.visitAdminPage("plugins.php");
 	await page.keyboard.press(`${modifier}+j`);


### PR DESCRIPTION
Cmd+K is the shortcut people already know, and WordPress has put its own command palette on every admin screen since 6.9 — the oldest version this plugin runs on. Nothing in there mentioned abilities, so the only ways in were Cmd+J or the admin bar item, both of which you have to be told about first.

Core's palette now offers "Run an ability…". Picking it closes core's palette and opens this one, from any admin screen and from inside the post editor.

- The whole ability catalog still stays out of core's palette. Core re-filters whatever a plugin hands it by matching the words you typed against each label, so a result found by meaning rather than by wording would be dropped instead of just ranked lower — which is the reason this plugin has its own palette at all.
- One entry covers everywhere, editor included. Nothing had to be registered twice.
- Core's palette closes before this one opens, otherwise the keyboard stays trapped in core's. The new test types into the search field straight after making the switch, rather than only checking that the palette appeared, because losing the keyboard is how this would break.
- The palette entry grows from 90.7KB to 91.3KB (29.4KB to 29.7KB over the wire).

_PR description generated by Claude._