### PR TITLE
Score what reaches the screen, and drop the rank that never does

### DIFF
--- a/scripts/eval/score.mjs
+++ b/scripts/eval/score.mjs
@@ -5,6 +5,9 @@ import { rankFused } from "../../src/lib/rank.ts";
 
 const HERE = import.meta.dirname;
 
+// Measured in the browser: 40px rows in a 328px list at a 1280x720 viewport.
+const ROWS = 7;
+
 const read = (name) => JSON.parse(readFileSync(join(HERE, name), "utf8"));
 
 export const loadCatalog = (name = "catalog.json") => read(name);
@@ -26,6 +29,11 @@ const dot = (a, b) => a.reduce((sum, value, i) => sum + value * b[i], 0);
 
 const pct = (n, of) => (of ? `${((100 * n) / of).toFixed(0)}%` : "—");
 
+const median = (numbers) =>
+	[...numbers].sort((a, b) => a - b)[numbers.length >> 1] ?? 0;
+
+const targets = ({ expect }) => (Array.isArray(expect) ? expect : [expect]);
+
 const vectorsFor = async ({ embed, catalog, cases }) => {
 	const vectors = await embed(catalog.map(embedText));
 	const asked = await embed(cases.map(({ query }) => query));
@@ -36,84 +44,80 @@ const vectorsFor = async ({ embed, catalog, cases }) => {
 	};
 };
 
+const rankAll = ({ items, cases, byId, asked, floor }) =>
+	cases.map(({ query, expect, kind }, i) => {
+		const similarity = (id) => {
+			const vector = byId.get(id);
+			return vector ? dot(asked[i], vector) : 0;
+		};
+		const ranked = rankFused(items, query, { similarity, floor }).map(
+			({ id }) => id,
+		);
+		const at = expect
+			? ranked.findIndex((id) => targets({ expect }).includes(id))
+			: -1;
+
+		return { query, expect, kind, shown: ranked.length, at, top: ranked[0] };
+	});
+
 export const sweep = async ({ label, embed, catalog, cases }) => {
 	const items = toItems(catalog);
 	const { byId, asked } = await vectorsFor({ embed, catalog, cases });
 
-	console.log(`\n${label} — floor sweep`);
-	console.log("  floor   top-5   never surfaced   false positives");
+	console.log(`\n${label} — floor sweep   (${catalog.length} abilities)`);
+	console.log("  floor   never found   in view   first row   false positives");
 	for (const floor of [0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4]) {
-		let top5 = 0;
-		let missing = 0;
-		let wanted = 0;
-		let falsePositives = 0;
-		for (const [i, { query, expect }] of cases.entries()) {
-			const similarity = (id) => {
-				const vector = byId.get(id);
-				return vector ? dot(asked[i], vector) : 0;
-			};
-			const ranked = rankFused(items, query, { similarity, floor }).map(
-				({ id }) => id,
-			);
-			if (!expect) {
-				if (ranked.length) falsePositives++;
-				continue;
-			}
-			wanted++;
-			const want = Array.isArray(expect) ? expect : [expect];
-			const at = ranked.findIndex((id) => want.includes(id));
-			if (at >= 0 && at < 5) top5++;
-			if (at < 0) missing++;
-		}
+		const scored = rankAll({ items, cases, byId, asked, floor });
+		const answerable = scored.filter(({ expect }) => expect);
+		const found = answerable.filter(({ at }) => at >= 0);
+
 		console.log(
-			`  ${floor.toFixed(2)}    ${pct(top5, wanted).padStart(5)}   ${String(missing).padStart(9)}        ${falsePositives}`,
+			[
+				`  ${floor.toFixed(2)}`,
+				String(answerable.length - found.length).padStart(11),
+				pct(
+					found.filter(({ at }) => at < ROWS).length,
+					answerable.length,
+				).padStart(9),
+				pct(
+					found.filter(({ at }) => at === 0).length,
+					answerable.length,
+				).padStart(11),
+				String(
+					scored.filter(({ expect, shown }) => !expect && shown).length,
+				).padStart(17),
+			].join(""),
 		);
 	}
 };
 
 export const score = async ({ label, embed, catalog, cases }) => {
 	const items = toItems(catalog);
-	const vectors = await embed(catalog.map(embedText));
-	const asked = await embed(cases.map(({ query }) => query));
-	const byId = new Map(catalog.map(({ name }, i) => [name, vectors[i]]));
+	const { byId, asked } = await vectorsFor({ embed, catalog, cases });
+	const scored = rankAll({ items, cases, byId, asked });
 
 	const kinds = new Map();
 	const notes = [];
 
-	for (const [i, { query, expect, kind }] of cases.entries()) {
-		const similarity = (id) => {
-			const vector = byId.get(id);
-			return vector ? dot(asked[i], vector) : 0;
-		};
-		const ranked = rankFused(items, query, { similarity }).map(({ id }) => id);
-
-		const bucket = kinds.get(kind) ?? {
-			n: 0,
-			top1: 0,
-			top3: 0,
-			top5: 0,
-			missing: 0,
-		};
+	for (const { query, expect, kind, at, top } of scored) {
+		const bucket = kinds.get(kind) ?? { n: 0, first: 0, inView: 0, missing: 0 };
 		bucket.n++;
 		kinds.set(kind, bucket);
 
 		if (!expect) {
-			if (ranked.length) {
+			if (top) {
 				bucket.missing++;
-				notes.push(`  ${kind} false positive  "${query}" -> ${ranked[0]}`);
+				notes.push(`  ${kind} false positive  "${query}" -> ${top}`);
 			}
 			continue;
 		}
 
-		const wanted = Array.isArray(expect) ? expect : [expect];
-		const at = ranked.findIndex((id) => wanted.includes(id));
-		if (at === 0) bucket.top1++;
-		if (at >= 0 && at < 3) bucket.top3++;
-		// Seven rows fit the list without scrolling, so five is comfortably in view.
-		if (at >= 0 && at < 5) bucket.top5++;
+		if (at === 0) bucket.first++;
+		// Counted, not assumed: a filtered list is nearly always shorter than ROWS.
+		if (at >= 0 && at < ROWS) bucket.inView++;
 		if (at < 0) {
 			bucket.missing++;
-			notes.push(`  ${kind} missed  "${query}" -> ${ranked[0] ?? "nothing"}`);
+			notes.push(`  ${kind} never found  "${query}" -> ${top ?? "nothing"}`);
 		}
 	}
 
@@ -121,24 +125,32 @@ export const score = async ({ label, embed, catalog, cases }) => {
 	const total = answerable.reduce(
 		(sum, [, b]) => ({
 			n: sum.n + b.n,
-			top1: sum.top1 + b.top1,
-			top3: sum.top3 + b.top3,
-			top5: sum.top5 + b.top5,
+			first: sum.first + b.first,
+			inView: sum.inView + b.inView,
 			missing: sum.missing + b.missing,
 		}),
-		{ n: 0, top1: 0, top3: 0, top5: 0, missing: 0 },
+		{ n: 0, first: 0, inView: 0, missing: 0 },
 	);
 
+	const row = (name, b) =>
+		[
+			`  ${name.padEnd(11)}`,
+			String(b.n).padStart(3),
+			pct(b.inView, b.n).padStart(9),
+			String(b.n - b.missing - b.inView).padStart(13),
+			pct(b.first, b.n).padStart(11),
+		].join("");
+
+	const shown = scored.map(({ shown: n }) => n);
 	console.log(`\n${label}   (${catalog.length} abilities in the catalog)`);
-	console.log("  kind         n   top-1   top-3   top-5   never surfaced");
-	for (const [kind, b] of answerable) {
-		console.log(
-			`  ${kind.padEnd(11)}${String(b.n).padStart(3)}   ${pct(b.top1, b.n).padStart(5)}   ${pct(b.top3, b.n).padStart(5)}   ${pct(b.top5, b.n).padStart(5)}   ${b.missing}`,
-		);
-	}
 	console.log(
-		`  ${"ALL".padEnd(11)}${String(total.n).padStart(3)}   ${pct(total.top1, total.n).padStart(5)}   ${pct(total.top3, total.n).padStart(5)}   ${pct(total.top5, total.n).padStart(5)}   ${total.missing}`,
+		`  ${shown.filter((n) => n > ROWS).length} of ${shown.length} queries return more than ${ROWS} rows` +
+			`  (median ${median(shown)}, max ${Math.max(...shown)})`,
 	);
+	console.log("  kind         n   in view   below fold   first row");
+	for (const [kind, b] of answerable) console.log(row(kind, b));
+	console.log(row("ALL", total));
+	console.log(`  never found  ${total.missing}/${total.n}`);
 
 	const none = kinds.get("none");
 	if (none) {


### PR DESCRIPTION
The eval has been reporting top-1, top-3 and top-5 since it was written, and none of them describe what a person actually gets.

Typing filters the list. Across 103 queries the median number of results is **two**, exactly one query returns more than the seven rows that fit on screen, and measured over both catalogs the target ability lands below the fold **zero times**. So either an ability is admitted and visible, or it isn't admitted at all — rank never costs anyone sight of it.

That means every model-versus-model difference reported here in top-1 terms was noise. The report now leads with `in view` and `never found`, keeps printing `below fold` so the claim is re-checked on every run instead of assumed, and prints the result-count median beside the row budget so the reasoning shows up in the output.

`first row` stays as its own column for a different reason: cmdk preselects the first option, so it's the difference between pressing Enter and reaching for an arrow key. Real, but unrelated to visibility.

The floor sweep is judged the same way, which surfaces something useful — lowering the floor barely moves `first row` (within a few points across four settings), because a lower floor adds candidates *below* the winner rather than displacing it. Admissions get cheaper than they looked.

No behaviour change to the plugin; this is the eval only.